### PR TITLE
Add heading dropdown and style improvements

### DIFF
--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -9,6 +9,7 @@
 
   /* kebab menu toggle */
   let menuOpen = false;
+  let headOpen = false;
 
   function toggleTheme() {
     theme.update((t) => (t === 'light' ? 'dark' : 'light'));
@@ -77,7 +78,19 @@
   <!-- Formatting -->
   <button on:click={fmt.bold}    title="Bold **text** (⌘‑B)"><b>B</b></button>
   <button on:click={fmt.italic}  title="Italic _text_ (⌘‑I)"><i>I</i></button>
-  <button on:click={fmt.heading} title="Heading # (⌘‑H)">H1</button>
+  <div class="menu">
+    <button on:click={() => (headOpen = !headOpen)} title="Heading">H#</button>
+    {#if headOpen}
+      <div class="dropdown" on:mouseleave={() => (headOpen = false)}>
+        <button on:click={() => { headOpen = false; fmt.h1(); }}>H1</button>
+        <button on:click={() => { headOpen = false; fmt.h2(); }}>H2</button>
+        <button on:click={() => { headOpen = false; fmt.h3(); }}>H3</button>
+        <button on:click={() => { headOpen = false; fmt.h4(); }}>H4</button>
+        <button on:click={() => { headOpen = false; fmt.h5(); }}>H5</button>
+        <button on:click={() => { headOpen = false; fmt.h6(); }}>H6</button>
+      </div>
+    {/if}
+  </div>
   <button on:click={fmt.link}    title="Link [txt](url)">🔗</button>
   <button on:click={fmt.image}   title="Image ![alt](url)">🖼️</button>
   <button on:click={fmt.codeblk} title="Code block ```">⎇</button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -100,7 +100,12 @@ function bullets(prefix: string) {
   const fmt = {
     bold:    () => editorRef.wrapSelection('**', '**', ''),
     italic:  () => editorRef.wrapSelection('_', '_', ''),
-    heading: () => editorRef.wrapSelection('# ', '', ''),
+    h1:      () => editorRef.wrapSelection('# ', '', ''),
+    h2:      () => editorRef.wrapSelection('## ', '', ''),
+    h3:      () => editorRef.wrapSelection('### ', '', ''),
+    h4:      () => editorRef.wrapSelection('#### ', '', ''),
+    h5:      () => editorRef.wrapSelection('##### ', '', ''),
+    h6:      () => editorRef.wrapSelection('###### ', '', ''),
     link:    () => editorRef.wrapSelection('[', '](https://)', ''),
     image:   () => editorRef.insertAtCursor('![alt](https://)', ),
     codeblk: () => editorRef.wrapSelection('```\n', '\n```', ''),

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,6 +96,13 @@ textarea {
   margin: 1rem 0 0.5rem;
   font-weight: 700;
 }
+
+.preview-content h1 { font-size: 2rem; }
+.preview-content h2 { font-size: 1.75rem; }
+.preview-content h3 { font-size: 1.5rem; }
+.preview-content h4 { font-size: 1.25rem; }
+.preview-content h5 { font-size: 1.1rem; }
+.preview-content h6 { font-size: 1rem; }
 .preview-content p,
 .preview-content ul,
 .preview-content ol,


### PR DESCRIPTION
## Summary
- add heading dropdown in the toolbar
- map heading actions for H1-H6
- enlarge heading sizes in preview for clarity

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fee20b1e08326b2247ec9e96746d3