### PR TITLE
Add Vitest and tests for front‑matter helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "eslint . && prettier --check .",
-		"format": "prettier --write ."
-	},
-	"devDependencies": {
+        "format": "prettier --write ."
+        ,"test": "vitest run"
+        },
+        "devDependencies": {
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",
 		"@sveltejs/adapter-auto": "^6.0.0",
@@ -34,8 +35,9 @@
 		"tailwindcss": "^4.0.0",
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.20.0",
-		"vite": "^6.2.6"
-	},
+                "vite": "^6.2.6",
+                "vitest": "^1.0.0"
+        },
 	"dependencies": {
 		"@types/markdown-it-emoji": "^3.0.1",
 		"@types/markdown-it-footnote": "^3.0.4",

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { parseFrontMatter, buildFrontMatter } from '../src/lib/utils';
+
+describe('parseFrontMatter', () => {
+  it('parses YAML front matter when present', () => {
+    const input = `---\ntitle: "Post"\ntags: [foo, bar]\n---\nBody text`;
+    const result = parseFrontMatter(input);
+    expect(result).not.toBeNull();
+    expect(result?.meta).toEqual({ title: 'Post', tags: ['foo', 'bar'] });
+    expect(result?.body).toBe('Body text');
+  });
+
+  it('returns null when no front matter found', () => {
+    const input = 'Just body';
+    expect(parseFrontMatter(input)).toBeNull();
+  });
+});
+
+describe('buildFrontMatter', () => {
+  it('creates a YAML block with trailing newline', () => {
+    const yaml = buildFrontMatter({
+      title: 'A',
+      author: 'B',
+      date: '2024-01-01',
+      tags: ['x', 'y']
+    });
+    const expected = `---\ntitle: "A"\nauthor: "B"\ndate: "2024-01-01"\ntags: [\"x\", \"y\"]\n---\n`;
+    expect(yaml).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- install Vitest and expose `npm test`
- add unit tests for `parseFrontMatter` and `buildFrontMatter`

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff08597a48326909ddefa2adf6c5c