### PR TITLE
Improve markdown editor UX

### DIFF
--- a/src/components/ConfirmDialog.svelte
+++ b/src/components/ConfirmDialog.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  export let message = '';
+  export let onConfirm: (v: boolean) => void;
+</script>
+<style>
+  .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+  }
+  .box {
+    background: var(--bg-light);
+    border: 1px solid var(--border);
+    padding: 1rem 1.5rem;
+    border-radius: 6px;
+    min-width: 240px;
+    text-align: center;
+  }
+  html.dark .box {
+    background: var(--bg-dark);
+  }
+  button {
+    margin: 0.5rem;
+    padding: 0.25rem 0.75rem;
+    background: none;
+    border: 1px solid var(--border);
+    cursor: pointer;
+  }
+</style>
+<div class="overlay">
+  <div class="box">
+    <div>{message}</div>
+    <div>
+      <button on:click={() => onConfirm(true)}>OK</button>
+      <button on:click={() => onConfirm(false)}>Cancel</button>
+    </div>
+  </div>
+</div>

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -32,6 +32,14 @@
     font-size: 1rem;
     cursor: pointer;
     padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    transition: background var(--transition);
+  }
+  .toolbar button:hover {
+    background: rgba(0, 0, 0, 0.05);
+  }
+  html.dark .toolbar button:hover {
+    background: rgba(255, 255, 255, 0.1);
   }
   .group-divider {
     width: 1px;


### PR DESCRIPTION
## Summary
- add a simple `ConfirmDialog` component for nicer prompts
- support indent/outdent and smart list continuation with `Tab` and `Enter`
- add heading function and safe formatting when inside code blocks
- style toolbar buttons with hover effects
- wire custom confirm dialog for opening files and session restore

## Testing
- `npm run lint` *(fails: cannot find eslint-config-prettier)*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff1d43d48832681ac21f387f9f1cd