### PR TITLE
Fix formatting toolbar functionality

### DIFF
--- a/src/components/MarkdownEditor.svelte
+++ b/src/components/MarkdownEditor.svelte
@@ -73,7 +73,7 @@
 
   $: updateLines($markdownContent);
 
- export function wrapSelection(prefix: string, suffix = prefix, placeholder = '') {
+export function wrapSelection(prefix: string, suffix = prefix, placeholder = '') {
     const { selectionStart: s, selectionEnd: e, value } = textareaEl;
     const selected = value.slice(s, e) || placeholder;
     const updated  = value.slice(0, s) + prefix + selected + suffix + value.slice(e);
@@ -85,7 +85,7 @@
     textareaEl.setSelectionRange(cursor, cursor);
   }
 
-  export function insertAtCursor(text:string, cursorOffset = 0) {
+export function insertAtCursor(text:string, cursorOffset = 0) {
     const {selectionStart:s, selectionEnd: e, value } = textareaEl;
     const updated = value.slice(0, s) + text + value.slice(e);
     textareaEl.value = updated;
@@ -94,6 +94,10 @@
     textareaEl.focus();
     textareaEl.setSelectionRange(cursor, cursor);
   }
+
+export function getTextarea(): HTMLTextAreaElement {
+  return textareaEl;
+}
 </script>
 <style>
   .editor-wrap {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -80,8 +80,7 @@
   }
 /* --- Ordered & Unordered list helpers --- */
 function bullets(prefix: string, ordered = false) {
-  const el = editorRef;             // textarea wrapper component
-  const ta = (el as any).$$.ctx[0]; // raw <textarea> element
+  const ta = editorRef.getTextarea();
   const { value, selectionStart: s, selectionEnd: e } = ta;
 
   // Grab the selected block (or current line if nothing selected)
@@ -130,14 +129,14 @@ function bullets(prefix: string, ordered = false) {
   /* ---------------- Formatting helpers ---------------- */
 
   function isInCodeBlock(pos: number) {
-    const ta = (editorRef as any).$$.ctx[0] as HTMLTextAreaElement;
+    const ta = editorRef.getTextarea();
     const before = ta.value.slice(0, pos);
     const fences = (before.match(/```/g) || []).length;
     return fences % 2 === 1;
   }
 
   function safeWrap(p: string, sfx = p) {
-    const ta = (editorRef as any).$$.ctx[0] as HTMLTextAreaElement;
+    const ta = editorRef.getTextarea();
     if (isInCodeBlock(ta.selectionStart)) {
       ask('Cannot format text inside a code block');
       return;
@@ -146,7 +145,7 @@ function bullets(prefix: string, ordered = false) {
   }
 
   function heading(level: number) {
-    const ta = (editorRef as any).$$.ctx[0] as HTMLTextAreaElement;
+    const ta = editorRef.getTextarea();
     const { value, selectionStart: s, selectionEnd: e } = ta;
     const startLine = value.lastIndexOf('\n', s - 1) + 1;
     let endLine = value.indexOf('\n', e);


### PR DESCRIPTION
## Summary
- expose MarkdownEditor DOM via `getTextarea`
- use `getTextarea` in +page.svelte instead of internal Svelte internals

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff35c7a4c8326a5831fed608e19ef