### PR TITLE
Fix line number alignment and subtle preview highlighting

### DIFF
--- a/src/components/MarkdownEditor.svelte
+++ b/src/components/MarkdownEditor.svelte
@@ -9,6 +9,9 @@
     if (textareaEl) {
       textareaEl.style.height = 'auto';
       textareaEl.style.height = textareaEl.scrollHeight + 'px';
+      if (lineNumEl) {
+        lineNumEl.style.height = textareaEl.style.height;
+      }
     }
   }
  
@@ -16,14 +19,15 @@
     const lines = text.split('\n').length || 1;
     if (lineNumEl) {
       lineNumEl.innerHTML = Array.from({ length: lines }, (_, i) => i + 1).join('<br>');
+      lineNumEl.style.height = textareaEl ? textareaEl.style.height : 'auto';
     }
+    autoSize();
   }
 
   function handleInput(e: Event) {
     const val = (e.target as HTMLTextAreaElement).value;
     markdownContent.set(val);
     updateLines(val);
-    autoSize();
   }
 
   function handleKeyDown(e: KeyboardEvent) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,7 @@ body {
 
 .line-numbers {
   background: rgba(0, 0, 0, 0.04);
+  line-height: 1.5;
 }
 html.dark .line-numbers {
   background: rgba(255, 255, 255, 0.05);
@@ -93,6 +94,9 @@ textarea {
 }
 
 /* -------- markdown preview styling -------- */
+.preview-content {
+  line-height: 1.5;
+}
 .preview-content h1,
 .preview-content h2,
 .preview-content h3,
@@ -153,7 +157,10 @@ html.dark .preview-content code {
   overflow-x: auto;
 }
 .preview-content [data-line]:hover {
-  background: rgba(125, 125, 125, 0.1);
+  background: rgba(180, 180, 180, 0.15);
+}
+html.dark .preview-content [data-line]:hover {
+  background: rgba(255, 255, 255, 0.08);
 }
 html.dark .preview-content pre {
   background: #2b2b2b;


### PR DESCRIPTION
## Summary
- adjust editor autosize to sync line number pane height
- keep preview and line numbers at consistent line height
- apply subtler preview highlight colors

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint config package missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ffeef53b48326b222c208b9676958