### PR TITLE
Improve UI styling and download button

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Start the development server:
 ```bash
 npm run dev
 ```
+
+## Usage Tips
+
+- Your work is automatically saved to `localStorage` on every change. Reloading
+  the page will offer to restore the previous session.
+- Use the **Download** button (⌘‑S) in the toolbar to save the current document
+  as a `.md` file. When supported, the native File System API is used.
+- A small *Unsaved* indicator appears in the toolbar whenever edits have not yet
+  been downloaded.

--- a/src/components/MarkdownEditor.svelte
+++ b/src/components/MarkdownEditor.svelte
@@ -141,6 +141,7 @@ export function getTextarea(): HTMLTextAreaElement {
     border-right: 1px solid var(--border);
     font-family: var(--mono);
     opacity: 0.6;
+    border-radius: var(--radius) 0 0 var(--radius);
   }
   textarea {
     flex: 1;
@@ -149,6 +150,8 @@ export function getTextarea(): HTMLTextAreaElement {
     resize: none;
     overflow-y: hidden;
     height: auto;
+    white-space: pre;
+    border-radius: var(--radius);
     font-family: var(--mono);
     line-height: 1.5;
     background: inherit;

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -29,6 +29,13 @@
     padding: 0 0.75rem;
     gap: 0.25rem;
     border-bottom: 1px solid var(--border);
+    background: linear-gradient(135deg, var(--bg-light), #f0f0f7);
+    border-radius: var(--radius) var(--radius) 0 0;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  }
+  html.dark .toolbar {
+    background: linear-gradient(135deg, #2b2b2b, #363636);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
   }
   .toolbar button {
     background: none;
@@ -36,7 +43,7 @@
     font-size: 1rem;
     cursor: pointer;
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--radius);
     transition: background var(--transition);
   }
   .toolbar button:hover {
@@ -55,6 +62,7 @@
     margin-left: auto;
     color: #d9534f;
     font-style: italic;
+    font-weight: bold;
   }
   html.dark .unsaved { color: #e07a5f; }
 
@@ -83,7 +91,7 @@
 <div class="toolbar">
   <!-- File -->
   <button on:click={onOpen} title="Open (⌘‑O)">📂 Open</button>
-  <button on:click={onSave} title="Save / Download (⌘‑S)">💾 Save</button>
+  <button on:click={onSave} title="Download (⌘‑S)">💾 Download</button>
 
   <div class="group-divider"></div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,6 +22,9 @@ body {
   --border: #c9c9c9;
   --accent: #0d6efd;
 
+  /* rounded corners */
+  --radius: 8px;
+
   /* misc */
   --mono: ui-monospace, "Courier New", monospace;
   --transition: 0.2s ease-in-out;
@@ -66,9 +69,23 @@ html.dark body {
   flex: 1;
   padding: 1rem;
   overflow: auto;
+  background: var(--bg-light);
+  border-radius: var(--radius);
+  box-shadow: inset 0 0 4px rgba(0,0,0,0.05);
+}
+html.dark .pane {
+  background: var(--bg-dark);
+  box-shadow: inset 0 0 4px rgba(255,255,255,0.05);
 }
 .preview-pane {
   scrollbar-width: none; /* Firefox */
+  border-radius: var(--radius);
+  background: var(--bg-light);
+  box-shadow: inset 0 0 4px rgba(0,0,0,0.05);
+}
+html.dark .preview-pane {
+  background: var(--bg-dark);
+  box-shadow: inset 0 0 4px rgba(255,255,255,0.05);
 }
 .preview-pane::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
## Summary
- style toolbar with gradient and rounded corners
- tweak pane and preview styling for a smoother look
- remove line wrapping from editor and round its edges
- rename Save button to Download
- document autosave and download behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841e492d95c8326acf17d826bd75cb7