### PR TITLE
Improve toolbar UI and add file naming

### DIFF
--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,145 +1,266 @@
 <script lang="ts">
-  import { theme, dirty, editorSettings, showLineNumbers } from '$lib/stores';
+	import { theme, dirty, editorSettings, showLineNumbers, fileName } from '$lib/stores';
 
-  /* handlers passed from +page */
-  export let onOpen: () => void;
-  export let onSave: () => void;
-  export let fmt: Record<string, () => void>;
-  export let showMetaPanel: () => void;
+	/* handlers passed from +page */
+	export let onOpen: () => void;
+	export let onSave: () => void;
+	export let fmt: Record<string, () => void>;
+	export let showMetaPanel: () => void;
 
-  /* kebab menu toggle */
-  let menuOpen = false;
-  let headOpen = false;
+	/* kebab menu toggle */
+	let menuOpen = false;
+	let headOpen = false;
+	let advOpen = false;
 
-  function toggleTheme() {
-    theme.update((t) => (t === 'light' ? 'dark' : 'light'));
-  }
+	function toggleTheme() {
+		theme.update((t) => (t === 'light' ? 'dark' : 'light'));
+	}
 
-  function toggleLines() {
-    editorSettings.update((s) => ({ ...s, showLineNumbers: !s.showLineNumbers }));
-  }
+	function toggleLines() {
+		editorSettings.update((s) => ({ ...s, showLineNumbers: !s.showLineNumbers }));
+	}
 </script>
+
+<div class="toolbar">
+	<!-- File -->
+	<button on:click={onOpen} title="Open (⌘‑O)" aria-label="Open file">📂 Open</button>
+	<button on:click={onSave} title="Download (⌘‑S)" aria-label="Download file">💾 Download</button>
+	<input
+		class="filename"
+		type="text"
+		bind:value={$fileName}
+		aria-label="File name"
+		placeholder="Untitled"
+	/>
+
+	<div class="group-divider"></div>
+
+	<!-- Formatting -->
+	<button on:click={fmt.bold} title="Bold **text** (⌘‑B)"><b>B</b></button>
+	<button on:click={fmt.italic} title="Italic _text_ (⌘‑I)"><i>I</i></button>
+	<div class="menu">
+		<button on:click={() => (headOpen = !headOpen)} title="Heading">H#</button>
+		{#if headOpen}
+			<div
+				class="dropdown"
+				on:mouseleave={() => (headOpen = false)}
+				aria-label="Heading"
+				role="menu"
+				tabindex="-1"
+			>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h1();
+					}}>H1</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h2();
+					}}>H2</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h3();
+					}}>H3</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h4();
+					}}>H4</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h5();
+					}}>H5</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h6();
+					}}>H6</button
+				>
+			</div>
+		{/if}
+	</div>
+	<button on:click={fmt.link} title="Link [txt](url)">🔗</button>
+	<button on:click={fmt.image} title="Image ![alt](url)">🖼️</button>
+	<button on:click={fmt.codeblk} title="Code block ```">⎇</button>
+	<button on:click={fmt.inline} title="Inline code `code`">⌘</button>
+	<button on:click={fmt.ul} title="• List">•</button>
+	<button on:click={fmt.ol} title="1. List">1.</button>
+	<button on:click={fmt.quote} title="> Quote">❝</button>
+	<button on:click={fmt.hr} title="Horizontal rule ---">—</button>
+	<div class="menu">
+		<button
+			on:click={() => (advOpen = !advOpen)}
+			title="Advanced formatting"
+			aria-haspopup="true"
+			aria-expanded={advOpen}>⚙️</button
+		>
+		{#if advOpen}
+			<div
+				class="dropdown"
+				on:mouseleave={() => (advOpen = false)}
+				aria-label="Advanced"
+				role="menu"
+				tabindex="-1"
+			>
+				<button
+					on:click={() => {
+						advOpen = false;
+						fmt.strike();
+					}}>~~strike~~</button
+				>
+				<button
+					on:click={() => {
+						advOpen = false;
+						fmt.table();
+					}}>table</button
+				>
+				<button
+					on:click={() => {
+						advOpen = false;
+						fmt.footnote();
+					}}>footnote</button
+				>
+			</div>
+		{/if}
+	</div>
+
+	<div class="group-divider"></div>
+
+	<!-- Theme -->
+	<button on:click={toggleTheme} title="Toggle theme" aria-label="Toggle theme">
+		{#if $theme === 'light'}🌙{:else}🌞{/if}
+	</button>
+	<button on:click={toggleLines} title="Toggle line numbers" aria-label="Toggle line numbers">
+		{#if $showLineNumbers}Hide lines{:else}Show lines{/if}
+	</button>
+
+	<!-- kebab -->
+	<div class="menu">
+		<button on:click={() => (menuOpen = !menuOpen)} title="More">⋯</button>
+		{#if menuOpen}
+			<div
+				class="dropdown"
+				on:mouseleave={() => (menuOpen = false)}
+				aria-label="More options"
+				role="menu"
+				tabindex="-1"
+			>
+				<button
+					on:click={() => {
+						menuOpen = false;
+						showMetaPanel();
+					}}>📝 Metadata</button
+				>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Dirty flag -->
+	{#if $dirty}<span class="unsaved-dot" aria-label="Unsaved changes" title="Unsaved changes"
+		></span>{/if}
+</div>
 
 <!-- svelte-ignore css_unused_selector -->
 <style>
-  .toolbar {
-    display: flex;
-    align-items: center;
-    height: 52px;
-    padding: 0 0.75rem;
-    gap: 0.25rem;
-    border-bottom: 1px solid var(--border);
-    background: linear-gradient(135deg, var(--bg-light), #f0f0f7);
-    border-radius: var(--radius) var(--radius) 0 0;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  }
-  html.dark .toolbar {
-    background: linear-gradient(135deg, #2b2b2b, #363636);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-  }
-  .toolbar button {
-    background: none;
-    border: none;
-    font-size: 1rem;
-    cursor: pointer;
-    padding: 0.25rem 0.5rem;
-    border-radius: var(--radius);
-    transition: background var(--transition);
-  }
-  .toolbar button:hover {
-    background: rgba(0, 0, 0, 0.05);
-  }
-  html.dark .toolbar button:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-  .group-divider {
-    width: 1px;
-    height: 60%;
-    background: var(--border);
-    margin: 0 0.25rem;
-  }
-  .unsaved {
-    margin-left: auto;
-    color: #d9534f;
-    font-style: italic;
-    font-weight: bold;
-  }
-  html.dark .unsaved { color: #e07a5f; }
+	.toolbar {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		height: auto;
+		padding: 0.25rem 0.5rem;
+		gap: 0.25rem;
+		border-bottom: 1px solid var(--border);
+		background: linear-gradient(135deg, var(--bg-light), #f0f0f7);
+		border-radius: var(--radius) var(--radius) 0 0;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+	}
+	html.dark .toolbar {
+		background: linear-gradient(135deg, #2b2b2b, #363636);
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+	}
+	.toolbar button {
+		background: none;
+		border: none;
+		font-size: 1rem;
+		cursor: pointer;
+		padding: 0.25rem 0.5rem;
+		border-radius: var(--radius);
+		transition: background var(--transition);
+	}
+	.toolbar button:hover {
+		background: rgba(0, 0, 0, 0.05);
+	}
+	html.dark .toolbar button:hover {
+		background: rgba(255, 255, 255, 0.1);
+	}
+	.group-divider {
+		width: 1px;
+		height: 60%;
+		background: var(--border);
+		margin: 0 0.25rem;
+	}
+	.filename {
+		flex: 1 1 120px;
+		min-width: 100px;
+		padding: 0.25rem 0.5rem;
+		border: 1px solid var(--border);
+		background: inherit;
+		color: inherit;
+	}
+	.unsaved-dot {
+		margin-left: auto;
+		width: 0.75rem;
+		height: 0.75rem;
+		border-radius: 50%;
+		background: #d9534f;
+	}
+	html.dark .unsaved-dot {
+		background: #e07a5f;
+	}
 
-  /* kebab dropdown */
-  .menu {
-    position: relative;
-  }
-  .dropdown {
-    position: absolute;
-    right: 0;
-    top: 130%;
-    background: var(--bg-light);
-    border: 1px solid var(--border);
-    padding: 0.25rem 0;
-    z-index: 10;
-  }
-  html.dark .dropdown { background: var(--bg-dark); }
-  .dropdown button {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 0.4rem 0.75rem;
-  }
+	/* kebab dropdown */
+	.menu {
+		position: relative;
+	}
+	.dropdown {
+		position: absolute;
+		right: 0;
+		top: 130%;
+		background: var(--bg-light);
+		border: 1px solid var(--border);
+		padding: 0.25rem 0;
+		z-index: 10;
+	}
+	html.dark .dropdown {
+		background: var(--bg-dark);
+	}
+	.dropdown button {
+		display: block;
+		width: 100%;
+		text-align: left;
+		padding: 0.4rem 0.75rem;
+	}
+	@media (max-width: 600px) {
+		.toolbar {
+			flex-direction: column;
+			align-items: stretch;
+		}
+		.group-divider {
+			width: 100%;
+			height: 1px;
+			margin: 0.25rem 0;
+		}
+		.unsaved-dot {
+			align-self: flex-end;
+			margin-left: 0;
+		}
+	}
 </style>
-
-<div class="toolbar">
-  <!-- File -->
-  <button on:click={onOpen} title="Open (⌘‑O)">📂 Open</button>
-  <button on:click={onSave} title="Download (⌘‑S)">💾 Download</button>
-
-  <div class="group-divider"></div>
-
-  <!-- Formatting -->
-  <button on:click={fmt.bold}    title="Bold **text** (⌘‑B)"><b>B</b></button>
-  <button on:click={fmt.italic}  title="Italic _text_ (⌘‑I)"><i>I</i></button>
-  <div class="menu">
-    <button on:click={() => (headOpen = !headOpen)} title="Heading">H#</button>
-    {#if headOpen}
-      <div class="dropdown" on:mouseleave={() => (headOpen = false)} aria-label="Heading" role="menu" tabindex="-1">
-        <button on:click={() => { headOpen = false; fmt.h1(); }}>H1</button>
-        <button on:click={() => { headOpen = false; fmt.h2(); }}>H2</button>
-        <button on:click={() => { headOpen = false; fmt.h3(); }}>H3</button>
-        <button on:click={() => { headOpen = false; fmt.h4(); }}>H4</button>
-        <button on:click={() => { headOpen = false; fmt.h5(); }}>H5</button>
-        <button on:click={() => { headOpen = false; fmt.h6(); }}>H6</button>
-      </div>
-    {/if}
-  </div>
-  <button on:click={fmt.link}    title="Link [txt](url)">🔗</button>
-  <button on:click={fmt.image}   title="Image ![alt](url)">🖼️</button>
-  <button on:click={fmt.codeblk} title="Code block ```">⎇</button>
-  <button on:click={fmt.inline}  title="Inline code `code`">⌘</button>
-  <button on:click={fmt.ul}      title="• List">•</button>
-  <button on:click={fmt.ol}      title="1. List">1.</button>
-  <button on:click={fmt.quote}   title="> Quote">❝</button>
-  <button on:click={fmt.hr}      title="Horizontal rule ---">—</button>
-
-  <div class="group-divider"></div>
-
-  <!-- Theme -->
-  <button on:click={toggleTheme} title="Toggle theme">
-    {#if $theme === 'light'}🌙{:else}🌞{/if}
-  </button>
-  <button on:click={toggleLines} title="Toggle line numbers">
-    {#if $showLineNumbers}🔢{:else}🚫🔢{/if}
-  </button>
-
-  <!-- kebab -->
-  <div class="menu">
-    <button on:click={() => (menuOpen = !menuOpen)} title="More">⋯</button>
-    {#if menuOpen}
-      <div class="dropdown" on:mouseleave={() => (menuOpen = false)} aria-label="More options" role="menu" tabindex="-1">
-        <button on:click={() => { menuOpen = false; showMetaPanel(); }}>📝 Metadata</button>
-      </div>
-    {/if}
-  </div>
-
-  <!-- Dirty flag -->
-  {#if $dirty}<span class="unsaved">Unsaved</span>{/if}
-</div>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -10,55 +10,60 @@ export const htmlContent = derived(markdownContent, renderMarkdown);
 
 /* ------------ dirty flag (derived) ------------ */
 
-const lastSaved = writable<string>('');        // buffer at last explicit save
+const lastSaved = writable<string>(''); // buffer at last explicit save
 
-export const dirty = derived(
-  [markdownContent, lastSaved],
-  ([curr, saved]) => curr !== saved
-);
+export const dirty = derived([markdownContent, lastSaved], ([curr, saved]) => curr !== saved);
 
 /* expose helper for save handler */
 export function markSaved(val: string) {
-  lastSaved.set(val);
+	lastSaved.set(val);
 }
 
 /* ------------ theme ------------ */
 
 const savedTheme =
-  typeof localStorage !== 'undefined' ? localStorage.getItem('markdown-editor-theme') : null;
+	typeof localStorage !== 'undefined' ? localStorage.getItem('markdown-editor-theme') : null;
 export const theme = writable<'light' | 'dark'>((savedTheme as any) ?? 'light');
 
+/* ------------ file name ------------ */
+const savedName =
+	typeof localStorage !== 'undefined' ? localStorage.getItem('markdown-editor-name') : null;
+export const fileName = writable<string>(savedName ?? 'Untitled');
+fileName.subscribe((n) => {
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem('markdown-editor-name', n);
+	}
+});
+
 theme.subscribe((t) => {
-  if (typeof document !== 'undefined') {
-    document.documentElement.classList.toggle('dark', t === 'dark');
-    document.documentElement.classList.toggle('light', t === 'light');
-  }
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('markdown-editor-theme', t);
-  }
+	if (typeof document !== 'undefined') {
+		document.documentElement.classList.toggle('dark', t === 'dark');
+		document.documentElement.classList.toggle('light', t === 'light');
+	}
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem('markdown-editor-theme', t);
+	}
 });
 
 /* ------------ editor settings ------------ */
 
 export interface EditorSettings {
-  showLineNumbers: boolean;
+	showLineNumbers: boolean;
 }
 
 const defaultSettings: EditorSettings = { showLineNumbers: true };
 
 const savedSettings =
-  typeof localStorage !== 'undefined'
-    ? localStorage.getItem('markdown-editor-settings')
-    : null;
+	typeof localStorage !== 'undefined' ? localStorage.getItem('markdown-editor-settings') : null;
 
 export const editorSettings = writable<EditorSettings>(
-  savedSettings ? { ...defaultSettings, ...JSON.parse(savedSettings) } : defaultSettings
+	savedSettings ? { ...defaultSettings, ...JSON.parse(savedSettings) } : defaultSettings
 );
 
 editorSettings.subscribe((val) => {
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('markdown-editor-settings', JSON.stringify(val));
-  }
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem('markdown-editor-settings', JSON.stringify(val));
+	}
 });
 
 export const showLineNumbers = derived(editorSettings, (s) => s.showLineNumbers);
@@ -66,6 +71,6 @@ export const showLineNumbers = derived(editorSettings, (s) => s.showLineNumbers)
 /* ------------ throttled localStorage autosave ------------ */
 
 if (typeof window !== 'undefined') {
-  const saveToLS = debounce((v: string) => localStorage.setItem('markdown-editor-content', v));
-  markdownContent.subscribe(saveToLS);
+	const saveToLS = debounce((v: string) => localStorage.setItem('markdown-editor-content', v));
+	markdownContent.subscribe(saveToLS);
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,266 +1,264 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { get } from 'svelte/store';
-  import { markdownContent, dirty, markSaved } from '$lib/stores';
-  import Toolbar from '$components/Toolbar.svelte';
-  import MarkdownEditor from '$components/MarkdownEditor.svelte';
-  import MarkdownPreview from '$components/MarkdownPreview.svelte';
-  import MetadataPanel from '$components/MetadataPanel.svelte';
-  import ConfirmDialog from '$components/ConfirmDialog.svelte';
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import { markdownContent, dirty, markSaved, fileName } from '$lib/stores';
+	import Toolbar from '$components/Toolbar.svelte';
+	import MarkdownEditor from '$components/MarkdownEditor.svelte';
+	import MarkdownPreview from '$components/MarkdownPreview.svelte';
+	import MetadataPanel from '$components/MetadataPanel.svelte';
+	import ConfirmDialog from '$components/ConfirmDialog.svelte';
 
-  /* refs */
-  let editorRef: InstanceType<typeof MarkdownEditor>;
-  let editorPane: HTMLDivElement;
-  let previewPane: HTMLDivElement;
-  let hiddenInput: HTMLInputElement;
-  let showMeta = false;
-  let confirmMsg = '';
-  let confirmResolve: (v: boolean) => void = () => {};
+	/* refs */
+	let editorRef: InstanceType<typeof MarkdownEditor>;
+	let editorPane: HTMLDivElement;
+	let previewPane: HTMLDivElement;
+	let hiddenInput: HTMLInputElement;
+	let showMeta = false;
+	let confirmMsg = '';
+	let confirmResolve: (v: boolean) => void = () => {};
 
-  function ask(msg: string): Promise<boolean> {
-    confirmMsg = msg;
-    return new Promise((res) => {
-      confirmResolve = res;
-    });
-  }
+	function ask(msg: string): Promise<boolean> {
+		confirmMsg = msg;
+		return new Promise((res) => {
+			confirmResolve = res;
+		});
+	}
 
-  function handleConfirm(val: boolean) {
-    confirmMsg = '';
-    confirmResolve(val);
-  }
+	function handleConfirm(val: boolean) {
+		confirmMsg = '';
+		confirmResolve(val);
+	}
 
-  const hasNativeFS = typeof window !== 'undefined' && 'showOpenFilePicker' in window;
+	const hasNativeFS = typeof window !== 'undefined' && 'showOpenFilePicker' in window;
 
-  /* ---------------- File Open / Save ---------------- */
+	/* ---------------- File Open / Save ---------------- */
 
-  async function onOpen() {
-    if (get(dirty) && !(await ask('You have unsaved work. Continue?'))) return;
-    if (hasNativeFS) {
-      try {
-        const [handle] = await (window as any).showOpenFilePicker({
-          types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
-        });
-        const file = await handle.getFile();
-        const text = await file.text();
-        markdownContent.set(text);
-        markSaved(text);
-      } catch {}
-    } else hiddenInput.click();
-  }
+	async function onOpen() {
+		if (get(dirty) && !(await ask('You have unsaved work. Continue?'))) return;
+		if (hasNativeFS) {
+			try {
+				const [handle] = await (window as any).showOpenFilePicker({
+					types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
+				});
+				const file = await handle.getFile();
+				const text = await file.text();
+				markdownContent.set(text);
+				fileName.set(file.name.replace(/\.md$/, ''));
+				markSaved(text);
+			} catch {}
+		} else hiddenInput.click();
+	}
 
-  async function onSave() {
-    const txt = get(markdownContent);
-    if (hasNativeFS) {
-      try {
-        const handle = await (window as any).showSaveFilePicker({
-          suggestedName: 'document.md',
-          types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
-        });
-        const w = await handle.createWritable();
-        await w.write(txt);
-        await w.close();
-        markSaved(txt);
-      } catch {}
-    } else {
-      const blob = new Blob([txt], { type: 'text/markdown' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url; a.download = 'document.md'; a.click();
-      URL.revokeObjectURL(url);
-      markSaved(txt);
-    }
-  }
+	async function onSave() {
+		const txt = get(markdownContent);
+		if (hasNativeFS) {
+			try {
+				const handle = await (window as any).showSaveFilePicker({
+					suggestedName: `${get(fileName)}.md`,
+					types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
+				});
+				const w = await handle.createWritable();
+				await w.write(txt);
+				await w.close();
+				markSaved(txt);
+			} catch {}
+		} else {
+			const blob = new Blob([txt], { type: 'text/markdown' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `${get(fileName)}.md`;
+			a.click();
+			URL.revokeObjectURL(url);
+			markSaved(txt);
+		}
+	}
 
-  function handleFile(e: Event) {
-    const file = (e.target as HTMLInputElement).files?.[0];
-    if (!file) return;
-    file.text().then((txt) => {
-      markdownContent.set(txt);
-      markSaved(txt);
-      hiddenInput.value = '';
-    });
-  }
-/* --- Ordered & Unordered list helpers --- */
-function bullets(prefix: string, ordered = false) {
-  const ta = editorRef.getTextarea();
-  const { value, selectionStart: s, selectionEnd: e } = ta;
+	function handleFile(e: Event) {
+		const file = (e.target as HTMLInputElement).files?.[0];
+		if (!file) return;
+		file.text().then((txt) => {
+			markdownContent.set(txt);
+			fileName.set(file.name.replace(/\.md$/, ''));
+			markSaved(txt);
+			hiddenInput.value = '';
+		});
+	}
+	/* --- Ordered & Unordered list helpers --- */
+	function bullets(prefix: string, ordered = false) {
+		const ta = editorRef.getTextarea();
+		const { value, selectionStart: s, selectionEnd: e } = ta;
 
-  // Grab the selected block (or current line if nothing selected)
-  const startLine = value.lastIndexOf('\n', s - 1) + 1;
-  let endLine = value.indexOf('\n', e);
-  if (endLine === -1) endLine = value.length;
-  const block  = value.slice(startLine, endLine);
-  const lines  = block.split('\n');
+		// Grab the selected block (or current line if nothing selected)
+		const startLine = value.lastIndexOf('\n', s - 1) + 1;
+		let endLine = value.indexOf('\n', e);
+		if (endLine === -1) endLine = value.length;
+		const block = value.slice(startLine, endLine);
+		const lines = block.split('\n');
 
-  const patched = lines
-    .map((ln: string, i: number) => {
-      const indent = ln.match(/^\s*/)?.[0] ?? '';
-      let text = ln.slice(indent.length);
+		const patched = lines
+			.map((ln: string, i: number) => {
+				const indent = ln.match(/^\s*/)?.[0] ?? '';
+				let text = ln.slice(indent.length);
 
-      if (ordered) {
-        const match = text.match(/^\d+\.\s+/);
-        if (match) {
-          // toggle off existing numbered list
-          text = text.slice(match[0].length);
-        } else {
-          text = `${i + 1}. ${text}`;
-        }
-      } else {
-        if (text.startsWith(prefix.trim())) {
-          text = text.slice(prefix.trim().length);
-        } else {
-          text = prefix + text;
-        }
-      }
+				if (ordered) {
+					const match = text.match(/^\d+\.\s+/);
+					if (match) {
+						// toggle off existing numbered list
+						text = text.slice(match[0].length);
+					} else {
+						text = `${i + 1}. ${text}`;
+					}
+				} else {
+					if (text.startsWith(prefix.trim())) {
+						text = text.slice(prefix.trim().length);
+					} else {
+						text = prefix + text;
+					}
+				}
 
-      return indent + text;
-    })
-    .join('\n');
+				return indent + text;
+			})
+			.join('\n');
 
-  const next = value.slice(0, startLine) + patched + value.slice(endLine);
-  ta.value = next;
-  markdownContent.set(next);
+		const next = value.slice(0, startLine) + patched + value.slice(endLine);
+		ta.value = next;
+		markdownContent.set(next);
 
-  // keep selection
-  const newEnd = startLine + patched.length;
-  ta.setSelectionRange(startLine, newEnd);
-  ta.focus();
-}
+		// keep selection
+		const newEnd = startLine + patched.length;
+		ta.setSelectionRange(startLine, newEnd);
+		ta.focus();
+	}
 
+	/* ---------------- Formatting helpers ---------------- */
 
-  /* ---------------- Formatting helpers ---------------- */
+	function isInCodeBlock(pos: number) {
+		const ta = editorRef.getTextarea();
+		const before = ta.value.slice(0, pos);
+		const fences = (before.match(/```/g) || []).length;
+		return fences % 2 === 1;
+	}
 
-  function isInCodeBlock(pos: number) {
-    const ta = editorRef.getTextarea();
-    const before = ta.value.slice(0, pos);
-    const fences = (before.match(/```/g) || []).length;
-    return fences % 2 === 1;
-  }
+	function safeWrap(p: string, sfx = p) {
+		const ta = editorRef.getTextarea();
+		if (isInCodeBlock(ta.selectionStart)) {
+			ask('Cannot format text inside a code block');
+			return;
+		}
+		editorRef.wrapSelection(p, sfx, '');
+	}
 
-  function safeWrap(p: string, sfx = p) {
-    const ta = editorRef.getTextarea();
-    if (isInCodeBlock(ta.selectionStart)) {
-      ask('Cannot format text inside a code block');
-      return;
-    }
-    editorRef.wrapSelection(p, sfx, '');
-  }
+	function heading(level: number) {
+		const ta = editorRef.getTextarea();
+		const { value, selectionStart: s, selectionEnd: e } = ta;
+		const startLine = value.lastIndexOf('\n', s - 1) + 1;
+		let endLine = value.indexOf('\n', e);
+		if (endLine === -1) endLine = value.length;
+		const lines = value.slice(startLine, endLine).split('\n');
+		const prefix = '#'.repeat(level) + ' ';
 
-  function heading(level: number) {
-    const ta = editorRef.getTextarea();
-    const { value, selectionStart: s, selectionEnd: e } = ta;
-    const startLine = value.lastIndexOf('\n', s - 1) + 1;
-    let endLine = value.indexOf('\n', e);
-    if (endLine === -1) endLine = value.length;
-    const lines = value.slice(startLine, endLine).split('\n');
-    const prefix = '#'.repeat(level) + ' ';
+		const patched = lines
+			.map((ln) => {
+				const stripped = ln.replace(/^#+\s+/, '');
+				if (ln.trim().startsWith(prefix)) return stripped;
+				return prefix + stripped;
+			})
+			.join('\n');
 
-    const patched = lines
-      .map((ln) => {
-        const stripped = ln.replace(/^#+\s+/, '');
-        if (ln.trim().startsWith(prefix)) return stripped;
-        return prefix + stripped;
-      })
-      .join('\n');
+		const next = value.slice(0, startLine) + patched + value.slice(endLine);
+		ta.value = next;
+		markdownContent.set(next);
+		const newEnd = startLine + patched.length;
+		ta.setSelectionRange(newEnd, newEnd);
+		ta.focus();
+	}
 
-    const next = value.slice(0, startLine) + patched + value.slice(endLine);
-    ta.value = next;
-    markdownContent.set(next);
-    const newEnd = startLine + patched.length;
-    ta.setSelectionRange(newEnd, newEnd);
-    ta.focus();
-  }
+	const fmt = {
+		bold: () => safeWrap('**', '**'),
+		italic: () => safeWrap('_', '_'),
+		h1: () => heading(1),
+		h2: () => heading(2),
+		h3: () => heading(3),
+		h4: () => heading(4),
+		h5: () => heading(5),
+		h6: () => heading(6),
+		link: () => editorRef.wrapSelection('[', '](https://)', ''),
+		image: () => editorRef.insertAtCursor('![alt](https://)'),
+		codeblk: () => editorRef.wrapSelection('```\n', '\n```', ''),
+		inline: () => editorRef.wrapSelection('`', '`', 'code'),
+		ul: () => bullets('- '),
+		ol: () => bullets('1. ', true),
+		quote: () => editorRef.wrapSelection('> ', '', ''),
+		hr: () => editorRef.insertAtCursor('\n---\n'),
+		strike: () => safeWrap('~~', '~~'),
+		table: () =>
+			editorRef.insertAtCursor('| Header | Header |\n| ------ | ------ |\n| Cell | Cell |\n'),
+		footnote: () => editorRef.insertAtCursor('[^1]\n\n[^1]: ')
+	};
 
-  const fmt = {
-    bold:    () => safeWrap('**', '**'),
-    italic:  () => safeWrap('_', '_'),
-    h1:      () => heading(1),
-    h2:      () => heading(2),
-    h3:      () => heading(3),
-    h4:      () => heading(4),
-    h5:      () => heading(5),
-    h6:      () => heading(6),
-    link:    () => editorRef.wrapSelection('[', '](https://)', ''),
-    image:   () => editorRef.insertAtCursor('![alt](https://)', ),
-    codeblk: () => editorRef.wrapSelection('```\n', '\n```', ''),
-    inline:  () => editorRef.wrapSelection('`', '`', 'code'),
-    ul:      () => bullets('- '),
-    ol:      () => bullets('1. ', true),
-    quote:   () => editorRef.wrapSelection('> ', '', ''),
-    hr:      () => editorRef.insertAtCursor('\n---\n')
-  };
+	/* ---------------- pane scroll syncing ---------------- */
+	let syncing = false;
+	function sync(source: 'editor' | 'preview') {
+		if (syncing) return;
+		syncing = true;
+		const src = source === 'editor' ? editorPane : previewPane;
+		const tgt = source === 'editor' ? previewPane : editorPane;
+		const ratio = src.scrollTop / (src.scrollHeight - src.clientHeight || 1);
+		tgt.scrollTop = ratio * (tgt.scrollHeight - tgt.clientHeight);
+		syncing = false;
+	}
 
-  /* ---------------- pane scroll syncing ---------------- */
-  let syncing = false;
-  function sync(source: 'editor' | 'preview') {
-    if (syncing) return;
-    syncing = true;
-    const src = source === 'editor' ? editorPane : previewPane;
-    const tgt = source === 'editor' ? previewPane : editorPane;
-    const ratio = src.scrollTop / (src.scrollHeight - src.clientHeight || 1);
-    tgt.scrollTop = ratio * (tgt.scrollHeight - tgt.clientHeight);
-    syncing = false;
-  }
+	function onHighlight(e: CustomEvent<{ line: number | null }>) {
+		editorRef.highlightLine(e.detail.line);
+	}
 
-  function onHighlight(e: CustomEvent<{ line: number | null }>) {
-    editorRef.highlightLine(e.detail.line);
-  }
+	function onJump(e: CustomEvent<{ line: number }>) {
+		editorRef.jumpToLine(e.detail.line);
+	}
 
-  function onJump(e: CustomEvent<{ line: number }>) {
-    editorRef.jumpToLine(e.detail.line);
-  }
+	/* ---------------- session restore ---------------- */
 
-  /* ---------------- session restore ---------------- */
+	onMount(() => {
+		const cached = localStorage.getItem('markdown-editor-content');
+		if (cached) {
+			ask('Load previous session?').then((ok) => {
+				if (ok) markdownContent.set(cached);
+			});
+		}
 
-  onMount(() => {
-    const cached = localStorage.getItem('markdown-editor-content');
-    if (cached) {
-      ask('Load previous session?').then((ok) => {
-        if (ok) markdownContent.set(cached);
-      });
-    }
-
-    // removed native unload prompt to avoid intrusive dialogs
-  });
+		// removed native unload prompt to avoid intrusive dialogs
+	});
 </script>
+
+<svelte:head>
+	<title>{$fileName}</title>
+</svelte:head>
 
 <!-- hidden input fallback -->
 <input
-  type="file"
-  accept=".md,.markdown,text/markdown"
-  bind:this={hiddenInput}
-  on:change={handleFile}
-  style="display:none"
+	type="file"
+	accept=".md,.markdown,text/markdown"
+	bind:this={hiddenInput}
+	on:change={handleFile}
+	style="display:none"
 />
 
 <!-- optional metadata panel -->
 {#if showMeta}
-  <MetadataPanel closePanel={() => (showMeta = false)} />
+	<MetadataPanel closePanel={() => (showMeta = false)} />
 {/if}
 
-<Toolbar
-  onOpen={onOpen}
-  onSave={onSave}
-  fmt={fmt}
-  showMetaPanel={() => (showMeta = !showMeta)}
-/>
+<Toolbar {onOpen} {onSave} {fmt} showMetaPanel={() => (showMeta = !showMeta)} />
 
 <div class="editor-layout">
-  <div
-    class="pane editor-pane"
-    bind:this={editorPane}
-    on:scroll={() => sync('editor')}
-  >
-    <MarkdownEditor bind:this={editorRef} />
-  </div>
-  <div
-    class="pane preview-pane"
-    bind:this={previewPane}
-    on:scroll={() => sync('preview')}
-  >
-    <MarkdownPreview on:highlight={onHighlight} on:jump={onJump} />
-  </div>
+	<div class="pane editor-pane" bind:this={editorPane} on:scroll={() => sync('editor')}>
+		<MarkdownEditor bind:this={editorRef} />
+	</div>
+	<div class="pane preview-pane" bind:this={previewPane} on:scroll={() => sync('preview')}>
+		<MarkdownPreview on:highlight={onHighlight} on:jump={onJump} />
+	</div>
 </div>
 {#if confirmMsg}
-  <ConfirmDialog message={confirmMsg} onConfirm={handleConfirm} />
+	<ConfirmDialog message={confirmMsg} onConfirm={handleConfirm} />
 {/if}


### PR DESCRIPTION
## Summary
- add persistent fileName store
- integrate file name input in toolbar
- add advanced formatting menu
- replace line-number button with text
- show unsaved status as a small dot
- improve responsive toolbar styles
- update open/save handlers to use file name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e89cf8088326bc0cd9cbe6d63bb4