### PR TITLE
Fix lint issues and refine metadata title

### DIFF
--- a/src/components/ConfirmDialog.svelte
+++ b/src/components/ConfirmDialog.svelte
@@ -1,45 +1,47 @@
 <script lang="ts">
-  export let message = '';
-  export let onConfirm: (v: boolean) => void;
+	export let message = '';
+	export let onConfirm: (v: boolean) => void;
 </script>
-<style>
-  .overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0,0,0,0.4);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 50;
-  }
-  .box {
-    background: var(--bg-light);
-    border: 1px solid var(--border);
-    padding: 1rem 1.5rem;
-    border-radius: 6px;
-    min-width: 240px;
-    text-align: center;
-  }
-  html.dark .box {
-    background: var(--bg-dark);
-  }
-  button {
-    margin: 0.5rem;
-    padding: 0.25rem 0.75rem;
-    background: none;
-    border: 1px solid var(--border);
-    cursor: pointer;
-  }
-</style>
+
 <div class="overlay">
-  <div class="box">
-    <div>{message}</div>
-    <div>
-      <button on:click={() => onConfirm(true)}>OK</button>
-      <button on:click={() => onConfirm(false)}>Cancel</button>
-    </div>
-  </div>
+	<div class="box">
+		<div>{message}</div>
+		<div>
+			<button on:click={() => onConfirm(true)}>OK</button>
+			<button on:click={() => onConfirm(false)}>Cancel</button>
+		</div>
+	</div>
 </div>
+
+<style>
+	.overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.4);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 50;
+	}
+	.box {
+		background: var(--bg-light);
+		border: 1px solid var(--border);
+		padding: 1rem 1.5rem;
+		border-radius: 6px;
+		min-width: 240px;
+		text-align: center;
+	}
+	html.dark .box {
+		background: var(--bg-dark);
+	}
+	button {
+		margin: 0.5rem;
+		padding: 0.25rem 0.75rem;
+		background: none;
+		border: 1px solid var(--border);
+		cursor: pointer;
+	}
+</style>

--- a/src/components/MarkdownEditor.svelte
+++ b/src/components/MarkdownEditor.svelte
@@ -1,171 +1,173 @@
 <script lang="ts">
-  import { markdownContent } from '$lib/stores';
-  import { onMount } from 'svelte';
+	import { markdownContent } from '$lib/stores';
+	import { onMount } from 'svelte';
 
-  let textareaEl: HTMLTextAreaElement;
-  let lineNumEl: HTMLElement;
+	let textareaEl: HTMLTextAreaElement;
+	let lineNumEl: HTMLElement;
 
-  function autoSize() {
-    if (textareaEl) {
-      textareaEl.style.height = 'auto';
-      textareaEl.style.height = textareaEl.scrollHeight + 'px';
-      if (lineNumEl) {
-        lineNumEl.style.height = textareaEl.style.height;
-      }
-    }
-  }
- 
-  function updateLines(text: string) {
-    const lines = text.split('\n').length || 1;
-    if (lineNumEl) {
-      lineNumEl.innerHTML = Array.from({ length: lines }, (_, i) => `<div>${i + 1}</div>`).join('');
-      lineNumEl.style.height = textareaEl ? textareaEl.style.height : 'auto';
-    }
-    autoSize();
-  }
+	function autoSize() {
+		if (textareaEl) {
+			textareaEl.style.height = 'auto';
+			textareaEl.style.height = textareaEl.scrollHeight + 'px';
+			if (lineNumEl) {
+				lineNumEl.style.height = textareaEl.style.height;
+			}
+		}
+	}
 
-  function handleInput(e: Event) {
-    const val = (e.target as HTMLTextAreaElement).value;
-    markdownContent.set(val);
-    updateLines(val);
-  }
+	function updateLines(text: string) {
+		const lines = text.split('\n').length || 1;
+		if (lineNumEl) {
+			// eslint-disable-next-line svelte/no-dom-manipulating
+			lineNumEl.innerHTML = Array.from({ length: lines }, (_, i) => `<div>${i + 1}</div>`).join('');
+			lineNumEl.style.height = textareaEl ? textareaEl.style.height : 'auto';
+		}
+		autoSize();
+	}
 
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      const { selectionStart: s, selectionEnd: end, value } = textareaEl;
-      const startLine = value.lastIndexOf('\n', s - 1) + 1;
-      let endLine = value.indexOf('\n', end);
-      if (endLine === -1) endLine = value.length;
-      const lines = value.slice(startLine, endLine).split('\n');
+	function handleInput(e: Event) {
+		const val = (e.target as HTMLTextAreaElement).value;
+		markdownContent.set(val);
+		updateLines(val);
+	}
 
-      const patched = lines
-        .map((ln) => {
-          if (e.shiftKey) {
-            if (ln.startsWith('    ')) return ln.slice(4);
-            if (ln.startsWith('\t')) return ln.slice(1);
-            return ln.replace(/^\s{1,4}/, '');
-          }
-          return '    ' + ln;
-        })
-        .join('\n');
+	function handleKeyDown(e: KeyboardEvent) {
+		if (e.key === 'Tab') {
+			e.preventDefault();
+			const { selectionStart: s, selectionEnd: end, value } = textareaEl;
+			const startLine = value.lastIndexOf('\n', s - 1) + 1;
+			let endLine = value.indexOf('\n', end);
+			if (endLine === -1) endLine = value.length;
+			const lines = value.slice(startLine, endLine).split('\n');
 
-      const next = value.slice(0, startLine) + patched + value.slice(endLine);
-      textareaEl.value = next;
-      markdownContent.set(next);
-      const newEnd = startLine + patched.length;
-      textareaEl.setSelectionRange(startLine, newEnd);
-      updateLines(next);
-      return;
-    }
+			const patched = lines
+				.map((ln) => {
+					if (e.shiftKey) {
+						if (ln.startsWith('    ')) return ln.slice(4);
+						if (ln.startsWith('\t')) return ln.slice(1);
+						return ln.replace(/^\s{1,4}/, '');
+					}
+					return '    ' + ln;
+				})
+				.join('\n');
 
-    if (e.key === 'Enter') {
-      const { selectionStart: s, value } = textareaEl;
-      const prevStart = value.lastIndexOf('\n', s - 1) + 1;
-      const prevLine = value.slice(prevStart, s);
-      const olMatch = prevLine.match(/^(\s*)(\d+)\.\s+/);
-      const ulMatch = prevLine.match(/^(\s*)([-*+] )/);
-      if (olMatch) {
-        e.preventDefault();
-        const indent = olMatch[1];
-        const num = Number(olMatch[2]) + 1;
-        const insertion = `\n${indent}${num}. `;
-        insertAtCursor(insertion, 0);
-        return;
-      }
-      if (ulMatch) {
-        e.preventDefault();
-        const indent = ulMatch[1];
-        const bullet = ulMatch[2];
-        const insertion = `\n${indent}${bullet}`;
-        insertAtCursor(insertion, 0);
-        return;
-      }
-    }
-  }
+			const next = value.slice(0, startLine) + patched + value.slice(endLine);
+			textareaEl.value = next;
+			markdownContent.set(next);
+			const newEnd = startLine + patched.length;
+			textareaEl.setSelectionRange(startLine, newEnd);
+			updateLines(next);
+			return;
+		}
 
-  $: updateLines($markdownContent);
-  $: autoSize();
-  onMount(autoSize);
+		if (e.key === 'Enter') {
+			const { selectionStart: s, value } = textareaEl;
+			const prevStart = value.lastIndexOf('\n', s - 1) + 1;
+			const prevLine = value.slice(prevStart, s);
+			const olMatch = prevLine.match(/^(\s*)(\d+)\.\s+/);
+			const ulMatch = prevLine.match(/^(\s*)([-*+] )/);
+			if (olMatch) {
+				e.preventDefault();
+				const indent = olMatch[1];
+				const num = Number(olMatch[2]) + 1;
+				const insertion = `\n${indent}${num}. `;
+				insertAtCursor(insertion, 0);
+				return;
+			}
+			if (ulMatch) {
+				e.preventDefault();
+				const indent = ulMatch[1];
+				const bullet = ulMatch[2];
+				const insertion = `\n${indent}${bullet}`;
+				insertAtCursor(insertion, 0);
+				return;
+			}
+		}
+	}
 
-  export function highlightLine(line: number | null) {
-    if (!textareaEl || line == null) return;
-    const lines = textareaEl.value.split('\n');
-    const start = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
-    const end = start + lines[line - 1].length;
-    textareaEl.setSelectionRange(start, end);
-  }
+	$: updateLines($markdownContent);
+	onMount(autoSize);
 
-  export function jumpToLine(line: number) {
-    if (!textareaEl) return;
-    const lines = textareaEl.value.split('\n');
-    const pos = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
-    textareaEl.focus();
-    textareaEl.setSelectionRange(pos, pos);
-  }
+	export function highlightLine(line: number | null) {
+		if (!textareaEl || line == null) return;
+		const lines = textareaEl.value.split('\n');
+		const start = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
+		const end = start + lines[line - 1].length;
+		textareaEl.setSelectionRange(start, end);
+	}
 
-export function wrapSelection(prefix: string, suffix = prefix, placeholder = '') {
-    const { selectionStart: s, selectionEnd: e, value } = textareaEl;
-    const selected = value.slice(s, e) || placeholder;
-    const updated  = value.slice(0, s) + prefix + selected + suffix + value.slice(e);
-    textareaEl.value = updated;
-    markdownContent.set(updated);
+	export function jumpToLine(line: number) {
+		if (!textareaEl) return;
+		const lines = textareaEl.value.split('\n');
+		const pos = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
+		textareaEl.focus();
+		textareaEl.setSelectionRange(pos, pos);
+	}
 
-    const cursor = s + prefix.length + (selected === placeholder ? 0 : selected.length);
-    textareaEl.focus();
-    textareaEl.setSelectionRange(cursor, cursor);
-  }
+	export function wrapSelection(prefix: string, suffix = prefix, placeholder = '') {
+		const { selectionStart: s, selectionEnd: e, value } = textareaEl;
+		const selected = value.slice(s, e) || placeholder;
+		const updated = value.slice(0, s) + prefix + selected + suffix + value.slice(e);
+		textareaEl.value = updated;
+		markdownContent.set(updated);
 
-export function insertAtCursor(text:string, cursorOffset = 0) {
-    const {selectionStart:s, selectionEnd: e, value } = textareaEl;
-    const updated = value.slice(0, s) + text + value.slice(e);
-    textareaEl.value = updated;
-    markdownContent.set(updated);
-    const cursor = s + text.length + cursorOffset;
-    textareaEl.focus();
-    textareaEl.setSelectionRange(cursor, cursor);
-  }
+		const cursor = s + prefix.length + (selected === placeholder ? 0 : selected.length);
+		textareaEl.focus();
+		textareaEl.setSelectionRange(cursor, cursor);
+	}
 
-export function getTextarea(): HTMLTextAreaElement {
-  return textareaEl;
-}
+	export function insertAtCursor(text: string, cursorOffset = 0) {
+		const { selectionStart: s, selectionEnd: e, value } = textareaEl;
+		const updated = value.slice(0, s) + text + value.slice(e);
+		textareaEl.value = updated;
+		markdownContent.set(updated);
+		const cursor = s + text.length + cursorOffset;
+		textareaEl.focus();
+		textareaEl.setSelectionRange(cursor, cursor);
+	}
+
+	export function getTextarea(): HTMLTextAreaElement {
+		return textareaEl;
+	}
 </script>
-<style>
-  .editor-wrap {
-    display: flex;
-    height: 100%;
-  }
-  .line-numbers {
-    user-select: none;
-    text-align: right;
-    padding: 0.5rem 0.75rem 0.5rem 0.25rem;
-    border-right: 1px solid var(--border);
-    font-family: var(--mono);
-    opacity: 0.6;
-  }
-  textarea {
-    flex: 1;
-    padding: 0.5rem 0.75rem;
-    border: none;
-    resize: none;
-    overflow-y: hidden;
-    height: auto;
-    font-family: var(--mono);
-    line-height: 1.5;
-    background: inherit;
-    color: inherit;
-    outline: none;
-  }
-</style>
+
 <!-- textarea automatically bound via store subscription -->
-<div class = "editor-wrap">
-    <pre class="line-numbers" bind:this={lineNumEl}></pre>
-    <textarea
-  bind:this={textareaEl}
-  bind:value={$markdownContent}
-  on:input={handleInput}
-  on:keydown={handleKeyDown}
-  spellcheck="false"
-  placeholder="# Start typing Markdown..."
-></textarea>
+<div class="editor-wrap">
+	<pre class="line-numbers" bind:this={lineNumEl}></pre>
+	<textarea
+		bind:this={textareaEl}
+		bind:value={$markdownContent}
+		on:input={handleInput}
+		on:keydown={handleKeyDown}
+		spellcheck="false"
+		placeholder="# Start typing Markdown..."
+	></textarea>
 </div>
+
+<style>
+	.editor-wrap {
+		display: flex;
+		height: 100%;
+	}
+	.line-numbers {
+		user-select: none;
+		text-align: right;
+		padding: 0.5rem 0.75rem 0.5rem 0.25rem;
+		border-right: 1px solid var(--border);
+		font-family: var(--mono);
+		opacity: 0.6;
+	}
+	textarea {
+		flex: 1;
+		padding: 0.5rem 0.75rem;
+		border: none;
+		resize: none;
+		overflow-y: hidden;
+		height: auto;
+		font-family: var(--mono);
+		line-height: 1.5;
+		background: inherit;
+		color: inherit;
+		outline: none;
+	}
+</style>

--- a/src/components/MarkdownPreview.svelte
+++ b/src/components/MarkdownPreview.svelte
@@ -1,25 +1,26 @@
 <script lang="ts">
-  import { htmlContent } from '$lib/stores';
-  import { createEventDispatcher } from 'svelte';
+	import { htmlContent } from '$lib/stores';
+	import { createEventDispatcher } from 'svelte';
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  function onHover(event: MouseEvent) {
-    const el = (event.target as HTMLElement).closest('[data-line]');
-    dispatch('highlight', { line: el ? Number(el.getAttribute('data-line')) : null });
-  }
+	function onHover(event: MouseEvent) {
+		const el = (event.target as HTMLElement).closest('[data-line]');
+		dispatch('highlight', { line: el ? Number(el.getAttribute('data-line')) : null });
+	}
 
-  function onClick(event: MouseEvent) {
-    const el = (event.target as HTMLElement).closest('[data-line]');
-    if (el) dispatch('jump', { line: Number(el.getAttribute('data-line')) });
-  }
+	function onClick(event: MouseEvent) {
+		const el = (event.target as HTMLElement).closest('[data-line]');
+		if (el) dispatch('jump', { line: Number(el.getAttribute('data-line')) });
+	}
 </script>
 
 <div
-  class="preview-content"
-  on:mouseover={onHover}
-  on:mouseleave={() => dispatch('highlight', { line: null })}
-  on:click={onClick}
+	class="preview-content"
+	on:mouseover={onHover}
+	on:mouseleave={() => dispatch('highlight', { line: null })}
+	on:click={onClick}
 >
-  {@html $htmlContent}
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html $htmlContent}
 </div>

--- a/src/components/MetadataPanel.svelte
+++ b/src/components/MetadataPanel.svelte
@@ -1,93 +1,97 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { markdownContent, dirty, markSaved } from '$lib/stores';
-  import { parseFrontMatter, buildFrontMatter } from '$lib/utils';
-  import { get } from 'svelte/store';
+	import { onMount } from 'svelte';
+	import { markdownContent, markSaved } from '$lib/stores';
+	import { parseFrontMatter, buildFrontMatter } from '$lib/utils';
+	import { get } from 'svelte/store';
 
-  export let closePanel: () => void;
+	export let closePanel: () => void;
 
-  /* form fields */
-  let title = '';
-  let author = '';
-  let date = '';
-  let tags = '';
+	/* form fields */
+	let title = '';
+	let author = '';
+	let date = '';
+	let tags = '';
 
-  /* ─── initial load: pull existing YAML (if any) ─── */
-  onMount(() => {
-    const parsed = parseFrontMatter(get(markdownContent));
-    if (parsed) {
-      const { meta, body } = parsed;
-      title  = (meta.title  ?? '') as string;
-      author = (meta.author ?? '') as string;
-      date   = (meta.date   ?? '') as string;
-      tags   = Array.isArray(meta.tags)
-        ? (meta.tags as string[]).join(', ')
-        : (meta.tags ?? '');
-      markdownContent.set(body);   // buffer now holds *body only*
-    }
-  });
+	/* ─── initial load: pull existing YAML (if any) ─── */
+	onMount(() => {
+		const parsed = parseFrontMatter(get(markdownContent));
+		if (parsed) {
+			const { meta, body } = parsed;
+			title = (meta.title ?? '') as string;
+			author = (meta.author ?? '') as string;
+			date = (meta.date ?? '') as string;
+			tags = Array.isArray(meta.tags) ? (meta.tags as string[]).join(', ') : (meta.tags ?? '');
+			markdownContent.set(body); // buffer now holds *body only*
+		}
+	});
 
-  /* ─── whenever any input changes, rebuild YAML once ─── */
-  $: {
-    /* turn "tag1, tag2" → ["tag1","tag2"] */
-    const tagArr = tags
-      .split(',')
-      .map((t) => t.trim())
-      .filter(Boolean);
+	/* ─── whenever any input changes, rebuild YAML once ─── */
+	$: {
+		/* turn "tag1, tag2" → ["tag1","tag2"] */
+		const tagArr = tags
+			.split(',')
+			.map((t) => t.trim())
+			.filter(Boolean);
 
-    const yaml  = buildFrontMatter({ title, author, date, tags: tagArr });
-    const buf   = get(markdownContent);
-    const body  = parseFrontMatter(buf)?.body ?? buf;   // strip existing YAML if present
-    const next  = `${yaml}${body}`;
+		const yaml = buildFrontMatter({ title, author, date, tags: tagArr });
+		const buf = get(markdownContent);
+		const body = parseFrontMatter(buf)?.body ?? buf; // strip existing YAML if present
+		const next = `${yaml}${body}`;
 
-    if (next !== buf) {
-      markdownContent.set(next);
-      markSaved(next);
-    }
-  }
+		if (next !== buf) {
+			markdownContent.set(next);
+			markSaved(next);
+		}
+	}
 </script>
 
-<style>
-  .panel {
-    border-bottom: 1px solid var(--border);
-    padding: 0.75rem 1rem;
-    display: grid;
-    gap: 0.5rem;
-    background: rgba(0, 0, 0, 0.02);
-  }
-  input {
-    padding: 0.3rem 0.5rem;
-    border: 1px solid var(--border);
-    background: inherit;
-    color: inherit;
-  }
-  button {
-    justify-self: start;
-    margin-top: 0.5rem;
-    background: none;
-    border: 1px solid var(--border);
-    padding: 0.25rem 0.6rem;
-    cursor: pointer;
-  }
-</style>
-
 <div class="panel">
-  <label>
-    Title
-    <input type="text" bind:value={title} />
-  </label>
-  <label>
-    Author
-    <input type="text" bind:value={author} />
-  </label>
-  <label>
-    Date
-    <input type="date" bind:value={date} />
-  </label>
-  <label>
-    Tags (comma‑separated)
-    <input type="text" bind:value={tags} />
-  </label>
+	<label>
+		Title
+		<input class="title" type="text" bind:value={title} />
+	</label>
+	<label>
+		Author
+		<input type="text" bind:value={author} />
+	</label>
+	<label>
+		Date
+		<input type="date" bind:value={date} />
+	</label>
+	<label>
+		Tags (comma-separated)
+		<input type="text" bind:value={tags} />
+	</label>
 
-  <button on:click={closePanel}>✓ Done</button>
+	<button on:click={closePanel}>✓ Done</button>
 </div>
+
+<style>
+	.panel {
+		border-bottom: 1px solid var(--border);
+		padding: 0.75rem 1rem;
+		display: grid;
+		gap: 0.5rem;
+		background: rgba(0, 0, 0, 0.02);
+	}
+	input {
+		padding: 0.3rem 0.5rem;
+		border: 1px solid var(--border);
+		background: inherit;
+		color: inherit;
+	}
+	input.title {
+		width: auto;
+		display: inline-block;
+		border: none;
+		border-bottom: 1px solid var(--border);
+	}
+	button {
+		justify-self: start;
+		margin-top: 0.5rem;
+		background: none;
+		border: 1px solid var(--border);
+		padding: 0.25rem 0.6rem;
+		cursor: pointer;
+	}
+</style>

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,130 +1,169 @@
 <script lang="ts">
-  import { theme, dirty } from '$lib/stores';
+	import { theme, dirty } from '$lib/stores';
 
-  /* handlers passed from +page */
-  export let onOpen: () => void;
-  export let onSave: () => void;
-  export let fmt: Record<string, () => void>;
-  export let showMetaPanel: () => void;
+	/* handlers passed from +page */
+	export let onOpen: () => void;
+	export let onSave: () => void;
+	export let fmt: Record<string, () => void>;
+	export let showMetaPanel: () => void;
 
-  /* kebab menu toggle */
-  let menuOpen = false;
-  let headOpen = false;
+	/* kebab menu toggle */
+	let menuOpen = false;
+	let headOpen = false;
 
-  function toggleTheme() {
-    theme.update((t) => (t === 'light' ? 'dark' : 'light'));
-  }
+	function toggleTheme() {
+		theme.update((t) => (t === 'light' ? 'dark' : 'light'));
+	}
 </script>
+
+<div class="toolbar">
+	<!-- File -->
+	<button on:click={onOpen} title="Open (⌘-O)">📂 Open</button>
+	<button on:click={onSave} title="Save / Download (⌘-S)">💾 Save</button>
+
+	<div class="group-divider"></div>
+
+	<!-- Formatting -->
+	<button on:click={fmt.bold} title="Bold **text** (⌘-B)"><b>B</b></button>
+	<button on:click={fmt.italic} title="Italic _text_ (⌘-I)"><i>I</i></button>
+	<div class="menu">
+		<button on:click={() => (headOpen = !headOpen)} title="Heading">H#</button>
+		{#if headOpen}
+			<div class="dropdown" on:mouseleave={() => (headOpen = false)}>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h1();
+					}}>H1</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h2();
+					}}>H2</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h3();
+					}}>H3</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h4();
+					}}>H4</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h5();
+					}}>H5</button
+				>
+				<button
+					on:click={() => {
+						headOpen = false;
+						fmt.h6();
+					}}>H6</button
+				>
+			</div>
+		{/if}
+	</div>
+	<button on:click={fmt.link} title="Link [txt](url)">🔗</button>
+	<button on:click={fmt.image} title="Image ![alt](url)">🖼️</button>
+	<button on:click={fmt.codeblk} title="Code block ```">⎇</button>
+	<button on:click={fmt.inline} title="Inline code `code`">⌘</button>
+	<button on:click={fmt.ul} title="• List">•</button>
+	<button on:click={fmt.ol} title="1. List">1.</button>
+	<button on:click={fmt.quote} title="> Quote">❝</button>
+	<button on:click={fmt.hr} title="Horizontal rule ---">—</button>
+
+	<div class="group-divider"></div>
+
+	<!-- Theme -->
+	<button on:click={toggleTheme} title="Toggle theme">
+		{#if $theme === 'light'}🌙{:else}🌞{/if}
+	</button>
+
+	<!-- kebab -->
+	<div class="menu">
+		<button on:click={() => (menuOpen = !menuOpen)} title="More">⋯</button>
+		{#if menuOpen}
+			<div class="dropdown" on:mouseleave={() => (menuOpen = false)}>
+				<button
+					on:click={() => {
+						menuOpen = false;
+						showMetaPanel();
+					}}>📝 Metadata</button
+				>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Dirty flag -->
+	{#if $dirty}<span class="unsaved">Unsaved</span>{/if}
+</div>
 
 <!-- svelte-ignore css_unused_selector -->
 <style>
-  .toolbar {
-    display: flex;
-    align-items: center;
-    height: 52px;
-    padding: 0 0.75rem;
-    gap: 0.25rem;
-    border-bottom: 1px solid var(--border);
-  }
-  .toolbar button {
-    background: none;
-    border: none;
-    font-size: 1rem;
-    cursor: pointer;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    transition: background var(--transition);
-  }
-  .toolbar button:hover {
-    background: rgba(0, 0, 0, 0.05);
-  }
-  html.dark .toolbar button:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-  .group-divider {
-    width: 1px;
-    height: 60%;
-    background: var(--border);
-    margin: 0 0.25rem;
-  }
-  .unsaved {
-    margin-left: auto;
-    color: #d9534f;
-    font-style: italic;
-  }
-  html.dark .unsaved { color: #e07a5f; }
+	.toolbar {
+		display: flex;
+		align-items: center;
+		height: 52px;
+		padding: 0 0.75rem;
+		gap: 0.25rem;
+		border-bottom: 1px solid var(--border);
+	}
+	.toolbar button {
+		background: none;
+		border: none;
+		font-size: 1rem;
+		cursor: pointer;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+		transition: background var(--transition);
+	}
+	.toolbar button:hover {
+		background: rgba(0, 0, 0, 0.05);
+	}
+	html.dark .toolbar button:hover {
+		background: rgba(255, 255, 255, 0.1);
+	}
+	.group-divider {
+		width: 1px;
+		height: 60%;
+		background: var(--border);
+		margin: 0 0.25rem;
+	}
+	.unsaved {
+		margin-left: auto;
+		color: #d9534f;
+		font-style: italic;
+	}
+	html.dark .unsaved {
+		color: #e07a5f;
+	}
 
-  /* kebab dropdown */
-  .menu {
-    position: relative;
-  }
-  .dropdown {
-    position: absolute;
-    right: 0;
-    top: 130%;
-    background: var(--bg-light);
-    border: 1px solid var(--border);
-    padding: 0.25rem 0;
-    z-index: 10;
-  }
-  html.dark .dropdown { background: var(--bg-dark); }
-  .dropdown button {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 0.4rem 0.75rem;
-  }
+	/* kebab dropdown */
+	.menu {
+		position: relative;
+	}
+	.dropdown {
+		position: absolute;
+		right: 0;
+		top: 130%;
+		background: var(--bg-light);
+		border: 1px solid var(--border);
+		padding: 0.25rem 0;
+		z-index: 10;
+	}
+	html.dark .dropdown {
+		background: var(--bg-dark);
+	}
+	.dropdown button {
+		display: block;
+		width: 100%;
+		text-align: left;
+		padding: 0.4rem 0.75rem;
+	}
 </style>
-
-<div class="toolbar">
-  <!-- File -->
-  <button on:click={onOpen} title="Open (⌘‑O)">📂 Open</button>
-  <button on:click={onSave} title="Save / Download (⌘‑S)">💾 Save</button>
-
-  <div class="group-divider"></div>
-
-  <!-- Formatting -->
-  <button on:click={fmt.bold}    title="Bold **text** (⌘‑B)"><b>B</b></button>
-  <button on:click={fmt.italic}  title="Italic _text_ (⌘‑I)"><i>I</i></button>
-  <div class="menu">
-    <button on:click={() => (headOpen = !headOpen)} title="Heading">H#</button>
-    {#if headOpen}
-      <div class="dropdown" on:mouseleave={() => (headOpen = false)}>
-        <button on:click={() => { headOpen = false; fmt.h1(); }}>H1</button>
-        <button on:click={() => { headOpen = false; fmt.h2(); }}>H2</button>
-        <button on:click={() => { headOpen = false; fmt.h3(); }}>H3</button>
-        <button on:click={() => { headOpen = false; fmt.h4(); }}>H4</button>
-        <button on:click={() => { headOpen = false; fmt.h5(); }}>H5</button>
-        <button on:click={() => { headOpen = false; fmt.h6(); }}>H6</button>
-      </div>
-    {/if}
-  </div>
-  <button on:click={fmt.link}    title="Link [txt](url)">🔗</button>
-  <button on:click={fmt.image}   title="Image ![alt](url)">🖼️</button>
-  <button on:click={fmt.codeblk} title="Code block ```">⎇</button>
-  <button on:click={fmt.inline}  title="Inline code `code`">⌘</button>
-  <button on:click={fmt.ul}      title="• List">•</button>
-  <button on:click={fmt.ol}      title="1. List">1.</button>
-  <button on:click={fmt.quote}   title="> Quote">❝</button>
-  <button on:click={fmt.hr}      title="Horizontal rule ---">—</button>
-
-  <div class="group-divider"></div>
-
-  <!-- Theme -->
-  <button on:click={toggleTheme} title="Toggle theme">
-    {#if $theme === 'light'}🌙{:else}🌞{/if}
-  </button>
-
-  <!-- kebab -->
-  <div class="menu">
-    <button on:click={() => (menuOpen = !menuOpen)} title="More">⋯</button>
-    {#if menuOpen}
-      <div class="dropdown" on:mouseleave={() => (menuOpen = false)}>
-        <button on:click={() => { menuOpen = false; showMetaPanel(); }}>📝 Metadata</button>
-      </div>
-    {/if}
-  </div>
-
-  <!-- Dirty flag -->
-  {#if $dirty}<span class="unsaved">Unsaved</span>{/if}
-</div>

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -3,46 +3,45 @@ import hljs from 'highlight.js';
 
 import mkfootnote from 'markdown-it-footnote';
 // import mkdeflist from 'markdown-it-deflist';
-import { full as emoji } from 'markdown-it-emoji'
+import { full as emoji } from 'markdown-it-emoji';
 // import mkmark from 'markdown-it-mark';
 // import mksub from 'markdown-it-sub';
 // import mksup from 'markdown-it-sup';
 // import mktask from 'markdown-it-task-lists';
-import mkanchor from 'markdown-it-anchor';
 // helper to annotate blocks with source line numbers
 function lineNumbers(md: MarkdownIt) {
-  md.core.ruler.after('block', 'line-numbers', (state) => {
-    state.tokens.forEach((t) => {
-      if (t.map && t.type.endsWith('_open')) {
-        t.attrSet('data-line', String(t.map[0] + 1));
-      }
-    });
-  });
+	md.core.ruler.after('block', 'line-numbers', (state) => {
+		state.tokens.forEach((t) => {
+			if (t.map && t.type.endsWith('_open')) {
+				t.attrSet('data-line', String(t.map[0] + 1));
+			}
+		});
+	});
 }
 export const md: MarkdownIt = new MarkdownIt({
-    html: true,
-    linkify: true,
-    typographer: true,
-    highlight:(code:string,lang:string) => {
-        if (lang && hljs.getLanguage(lang)) {
-            try{
-                return `<pre class="hljs"><code>${
-                hljs.highlight(code, { language: lang }).value
-                }</code></pre>`;
-            } catch {
-                console.log(`Error highlighting code with language ${lang}`);
-            }
-        }
-         return `<pre class="hljs"><code>${md.utils.escapeHtml(code)}</code></pre>`;
-    }
+	html: true,
+	linkify: true,
+	typographer: true,
+	highlight: (code: string, lang: string) => {
+		if (lang && hljs.getLanguage(lang)) {
+			try {
+				return `<pre class="hljs"><code>${
+					hljs.highlight(code, { language: lang }).value
+				}</code></pre>`;
+			} catch {
+				console.log(`Error highlighting code with language ${lang}`);
+			}
+		}
+		return `<pre class="hljs"><code>${md.utils.escapeHtml(code)}</code></pre>`;
+	}
 })
- // Footnotes: [^1], etc.
-  .use(mkfootnote)
-//   // Definition lists: term\n: definition
-//   .use(mkdeflist)
-//   // Emoji shortcodes like :joy:
-  .use(emoji)
-  .use(lineNumbers)
+	// Footnotes: [^1], etc.
+	.use(mkfootnote)
+	//   // Definition lists: term\n: definition
+	//   .use(mkdeflist)
+	//   // Emoji shortcodes like :joy:
+	.use(emoji)
+	.use(lineNumbers);
 //   // ==highlight==
 //   .use(mkmark)
 //   // Subscript: H~2~O
@@ -52,21 +51,21 @@ export const md: MarkdownIt = new MarkdownIt({
 //   // Task lists: - [ ] or - [x]
 //   .use(mktask, { enabled: true })
 //   // Heading anchors: ### Title {#custom-id}
-  // .use(mkanchor, {
-  //   // let `{#my-id}` syntax work
-  //   permalink: mkanchor.permalink.linkInsideHeader({
-  //     symbol: '¶',
-  //     placement: 'after'
-  //   }),
-  //   slugify: (s: string) =>
-  //     encodeURIComponent(
-  //       String(s)
-  //         .trim()
-  //         .toLowerCase()
-  //         .replace(/\s+/g, '-')
-  //     )
-  // });
+// .use(mkanchor, {
+//   // let `{#my-id}` syntax work
+//   permalink: mkanchor.permalink.linkInsideHeader({
+//     symbol: '¶',
+//     placement: 'after'
+//   }),
+//   slugify: (s: string) =>
+//     encodeURIComponent(
+//       String(s)
+//         .trim()
+//         .toLowerCase()
+//         .replace(/\s+/g, '-')
+//     )
+// });
 
 export function renderMarkdown(markdown: string): string {
-    return md.render(markdown);
+	return md.render(markdown);
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -10,37 +10,36 @@ export const htmlContent = derived(markdownContent, renderMarkdown);
 
 /* ------------ dirty flag (derived) ------------ */
 
-const lastSaved = writable<string>('');        // buffer at last explicit save
+const lastSaved = writable<string>(''); // buffer at last explicit save
 
-export const dirty = derived(
-  [markdownContent, lastSaved],
-  ([curr, saved]) => curr !== saved
-);
+export const dirty = derived([markdownContent, lastSaved], ([curr, saved]) => curr !== saved);
 
 /* expose helper for save handler */
 export function markSaved(val: string) {
-  lastSaved.set(val);
+	lastSaved.set(val);
 }
 
 /* ------------ theme ------------ */
 
 const savedTheme =
-  typeof localStorage !== 'undefined' ? localStorage.getItem('markdown-editor-theme') : null;
-export const theme = writable<'light' | 'dark'>((savedTheme as any) ?? 'light');
+	typeof localStorage !== 'undefined'
+		? (localStorage.getItem('markdown-editor-theme') as 'light' | 'dark' | null)
+		: null;
+export const theme = writable<'light' | 'dark'>(savedTheme ?? 'light');
 
 theme.subscribe((t) => {
-  if (typeof document !== 'undefined') {
-    document.documentElement.classList.toggle('dark', t === 'dark');
-    document.documentElement.classList.toggle('light', t === 'light');
-  }
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('markdown-editor-theme', t);
-  }
+	if (typeof document !== 'undefined') {
+		document.documentElement.classList.toggle('dark', t === 'dark');
+		document.documentElement.classList.toggle('light', t === 'light');
+	}
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem('markdown-editor-theme', t);
+	}
 });
 
 /* ------------ throttled localStorage autosave ------------ */
 
 if (typeof window !== 'undefined') {
-  const saveToLS = debounce((v: string) => localStorage.setItem('markdown-editor-content', v));
-  markdownContent.subscribe(saveToLS);
+	const saveToLS = debounce((v: string) => localStorage.setItem('markdown-editor-content', v));
+	markdownContent.subscribe(saveToLS);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,10 @@
 /** Simple debounce (used for throttled localStorage writes) */
-export function debounce<T extends (...a: any[]) => void>(fn: T, wait = 500): T {
-  let id: ReturnType<typeof setTimeout>;
-  return ((...args: any[]) => {
-    clearTimeout(id);
-    id = setTimeout(() => fn(...args), wait);
-  }) as T;
+export function debounce<T extends (...a: unknown[]) => void>(fn: T, wait = 500): T {
+	let id: ReturnType<typeof setTimeout>;
+	return ((...args: Parameters<T>) => {
+		clearTimeout(id);
+		id = setTimeout(() => fn(...args), wait);
+	}) as T;
 }
 /* -------------------------------------------------------------------
    YAML front‑matter helpers
@@ -24,49 +24,48 @@ export function debounce<T extends (...a: any[]) => void>(fn: T, wait = 500): T 
  *   - item2   <- (indented list not supported here)
  */
 export function parseFrontMatter(text: string): {
-  meta: Record<string, string | string[]>;
-  body: string;
+	meta: Record<string, string | string[]>;
+	body: string;
 } | null {
-  if (!text.startsWith('---')) return null;
-  const end = text.indexOf('\n---', 3);
-  if (end === -1) return null;
+	if (!text.startsWith('---')) return null;
+	const end = text.indexOf('\n---', 3);
+	if (end === -1) return null;
 
-  const yaml = text.slice(3, end).trim();
-  const meta: Record<string, any> = {};
+	const yaml = text.slice(3, end).trim();
+	const meta: Record<string, string | string[]> = {};
 
-  yaml.split('\n').forEach((line) => {
-    const [k, ...raw] = line.split(':');
-    if (!k || raw.length === 0) return;
-    const v = raw.join(':').trim();
-    if (v.startsWith('[') && v.endsWith(']')) {
-      meta[k.trim()] = v
-        .slice(1, -1)
-        .split(',')
-        .map((s) => s.trim().replace(/^['"]|['"]$/g, ''));
-    } else {
-      meta[k.trim()] = v.replace(/^['"]|['"]$/g, '');
-    }
-  });
+	yaml.split('\n').forEach((line) => {
+		const [k, ...raw] = line.split(':');
+		if (!k || raw.length === 0) return;
+		const v = raw.join(':').trim();
+		if (v.startsWith('[') && v.endsWith(']')) {
+			meta[k.trim()] = v
+				.slice(1, -1)
+				.split(',')
+				.map((s) => s.trim().replace(/^['"]|['"]$/g, ''));
+		} else {
+			meta[k.trim()] = v.replace(/^['"]|['"]$/g, '');
+		}
+	});
 
-  const body = text.slice(end + 4).replace(/^\s+/, ''); // trim leading newlines
-  return { meta, body };
+	const body = text.slice(end + 4).replace(/^\s+/, ''); // trim leading newlines
+	return { meta, body };
 }
 
 /**
  * buildFrontMatter — serialises fields into a YAML string with trailing `---`.
  */
 export function buildFrontMatter(fields: {
-  title?: string;
-  author?: string;
-  date?: string;
-  tags?: string[];
+	title?: string;
+	author?: string;
+	date?: string;
+	tags?: string[];
 }): string {
-  const lines: string[] = ['---'];
-  if (fields.title)  lines.push(`title: "${fields.title}"`);
-  if (fields.author) lines.push(`author: "${fields.author}"`);
-  if (fields.date)   lines.push(`date: "${fields.date}"`);
-  if (fields.tags?.length)
-    lines.push(`tags: [${fields.tags.map((t) => `"${t}"`).join(', ')}]`);
-  lines.push('---\n');
-  return lines.join('\n');
+	const lines: string[] = ['---'];
+	if (fields.title) lines.push(`title: "${fields.title}"`);
+	if (fields.author) lines.push(`author: "${fields.author}"`);
+	if (fields.date) lines.push(`date: "${fields.date}"`);
+	if (fields.tags?.length) lines.push(`tags: [${fields.tags.map((t) => `"${t}"`).join(', ')}]`);
+	lines.push('---\n');
+	return lines.join('\n');
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,271 +1,270 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { get } from 'svelte/store';
-  import { markdownContent, dirty, markSaved } from '$lib/stores';
-  import Toolbar from '$components/Toolbar.svelte';
-  import MarkdownEditor from '$components/MarkdownEditor.svelte';
-  import MarkdownPreview from '$components/MarkdownPreview.svelte';
-  import MetadataPanel from '$components/MetadataPanel.svelte';
-  import ConfirmDialog from '$components/ConfirmDialog.svelte';
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import { markdownContent, dirty, markSaved } from '$lib/stores';
+	import Toolbar from '$components/Toolbar.svelte';
+	import MarkdownEditor from '$components/MarkdownEditor.svelte';
+	import MarkdownPreview from '$components/MarkdownPreview.svelte';
+	import MetadataPanel from '$components/MetadataPanel.svelte';
+	import ConfirmDialog from '$components/ConfirmDialog.svelte';
 
-  /* refs */
-  let editorRef: InstanceType<typeof MarkdownEditor>;
-  let editorPane: HTMLDivElement;
-  let previewPane: HTMLDivElement;
-  let hiddenInput: HTMLInputElement;
-  let showMeta = false;
-  let confirmMsg = '';
-  let confirmResolve: (v: boolean) => void = () => {};
+	/* refs */
+	let editorRef: InstanceType<typeof MarkdownEditor>;
+	let editorPane: HTMLDivElement;
+	let previewPane: HTMLDivElement;
+	let hiddenInput: HTMLInputElement;
+	let showMeta = false;
+	let confirmMsg = '';
+	let confirmResolve: (v: boolean) => void = () => {};
 
-  function ask(msg: string): Promise<boolean> {
-    confirmMsg = msg;
-    return new Promise((res) => {
-      confirmResolve = res;
-    });
-  }
+	function ask(msg: string): Promise<boolean> {
+		confirmMsg = msg;
+		return new Promise((res) => {
+			confirmResolve = res;
+		});
+	}
 
-  function handleConfirm(val: boolean) {
-    confirmMsg = '';
-    confirmResolve(val);
-  }
+	function handleConfirm(val: boolean) {
+		confirmMsg = '';
+		confirmResolve(val);
+	}
 
-  const hasNativeFS = typeof window !== 'undefined' && 'showOpenFilePicker' in window;
+	interface FilePickerWindow extends Window {
+		showOpenFilePicker?: (opts: OpenFilePickerOptions) => Promise<FileSystemFileHandle[]>;
+		showSaveFilePicker?: (opts: SaveFilePickerOptions) => Promise<FileSystemFileHandle>;
+	}
 
-  /* ---------------- File Open / Save ---------------- */
+	const picker =
+		typeof window !== 'undefined' ? (window as FilePickerWindow) : ({} as FilePickerWindow);
+	const hasNativeFS = !!picker.showOpenFilePicker;
 
-  async function onOpen() {
-    if (get(dirty) && !(await ask('You have unsaved work. Continue?'))) return;
-    if (hasNativeFS) {
-      try {
-        const [handle] = await (window as any).showOpenFilePicker({
-          types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
-        });
-        const file = await handle.getFile();
-        const text = await file.text();
-        markdownContent.set(text);
-        markSaved(text);
-      } catch {}
-    } else hiddenInput.click();
-  }
+	/* ---------------- File Open / Save ---------------- */
 
-  async function onSave() {
-    const txt = get(markdownContent);
-    if (hasNativeFS) {
-      try {
-        const handle = await (window as any).showSaveFilePicker({
-          suggestedName: 'document.md',
-          types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
-        });
-        const w = await handle.createWritable();
-        await w.write(txt);
-        await w.close();
-        markSaved(txt);
-      } catch {}
-    } else {
-      const blob = new Blob([txt], { type: 'text/markdown' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url; a.download = 'document.md'; a.click();
-      URL.revokeObjectURL(url);
-      markSaved(txt);
-    }
-  }
+	async function onOpen() {
+		if (get(dirty) && !(await ask('You have unsaved work. Continue?'))) return;
+		if (hasNativeFS) {
+			try {
+				const [handle] = await picker.showOpenFilePicker!({
+					types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
+				});
+				const file = await handle.getFile();
+				const text = await file.text();
+				markdownContent.set(text);
+				markSaved(text);
+			} catch (err) {
+				console.error(err);
+			}
+		} else hiddenInput.click();
+	}
 
-  function handleFile(e: Event) {
-    const file = (e.target as HTMLInputElement).files?.[0];
-    if (!file) return;
-    file.text().then((txt) => {
-      markdownContent.set(txt);
-      markSaved(txt);
-      hiddenInput.value = '';
-    });
-  }
-/* --- Ordered & Unordered list helpers --- */
-function bullets(prefix: string, ordered = false) {
-  const ta = editorRef.getTextarea();
-  const { value, selectionStart: s, selectionEnd: e } = ta;
+	async function onSave() {
+		const txt = get(markdownContent);
+		if (hasNativeFS) {
+			try {
+				const handle = await picker.showSaveFilePicker!({
+					suggestedName: 'document.md',
+					types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
+				});
+				const w = await handle.createWritable();
+				await w.write(txt);
+				await w.close();
+				markSaved(txt);
+			} catch (err) {
+				console.error(err);
+			}
+		} else {
+			const blob = new Blob([txt], { type: 'text/markdown' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = 'document.md';
+			a.click();
+			URL.revokeObjectURL(url);
+			markSaved(txt);
+		}
+	}
 
-  // Grab the selected block (or current line if nothing selected)
-  const startLine = value.lastIndexOf('\n', s - 1) + 1;
-  let endLine = value.indexOf('\n', e);
-  if (endLine === -1) endLine = value.length;
-  const block  = value.slice(startLine, endLine);
-  const lines  = block.split('\n');
+	function handleFile(e: Event) {
+		const file = (e.target as HTMLInputElement).files?.[0];
+		if (!file) return;
+		file.text().then((txt) => {
+			markdownContent.set(txt);
+			markSaved(txt);
+			hiddenInput.value = '';
+		});
+	}
+	/* --- Ordered & Unordered list helpers --- */
+	function bullets(prefix: string, ordered = false) {
+		const ta = editorRef.getTextarea();
+		const { value, selectionStart: s, selectionEnd: e } = ta;
 
-  const patched = lines
-    .map((ln: string, i: number) => {
-      const indent = ln.match(/^\s*/)?.[0] ?? '';
-      let text = ln.slice(indent.length);
+		// Grab the selected block (or current line if nothing selected)
+		const startLine = value.lastIndexOf('\n', s - 1) + 1;
+		let endLine = value.indexOf('\n', e);
+		if (endLine === -1) endLine = value.length;
+		const block = value.slice(startLine, endLine);
+		const lines = block.split('\n');
 
-      if (ordered) {
-        const match = text.match(/^\d+\.\s+/);
-        if (match) {
-          // toggle off existing numbered list
-          text = text.slice(match[0].length);
-        } else {
-          text = `${i + 1}. ${text}`;
-        }
-      } else {
-        if (text.startsWith(prefix.trim())) {
-          text = text.slice(prefix.trim().length);
-        } else {
-          text = prefix + text;
-        }
-      }
+		const patched = lines
+			.map((ln: string, i: number) => {
+				const indent = ln.match(/^\s*/)?.[0] ?? '';
+				let text = ln.slice(indent.length);
 
-      return indent + text;
-    })
-    .join('\n');
+				if (ordered) {
+					const match = text.match(/^\d+\.\s+/);
+					if (match) {
+						// toggle off existing numbered list
+						text = text.slice(match[0].length);
+					} else {
+						text = `${i + 1}. ${text}`;
+					}
+				} else {
+					if (text.startsWith(prefix.trim())) {
+						text = text.slice(prefix.trim().length);
+					} else {
+						text = prefix + text;
+					}
+				}
 
-  const next = value.slice(0, startLine) + patched + value.slice(endLine);
-  ta.value = next;
-  markdownContent.set(next);
+				return indent + text;
+			})
+			.join('\n');
 
-  // keep selection
-  const newEnd = startLine + patched.length;
-  ta.setSelectionRange(startLine, newEnd);
-  ta.focus();
-}
+		const next = value.slice(0, startLine) + patched + value.slice(endLine);
+		ta.value = next;
+		markdownContent.set(next);
 
+		// keep selection
+		const newEnd = startLine + patched.length;
+		ta.setSelectionRange(startLine, newEnd);
+		ta.focus();
+	}
 
-  /* ---------------- Formatting helpers ---------------- */
+	/* ---------------- Formatting helpers ---------------- */
 
-  function isInCodeBlock(pos: number) {
-    const ta = editorRef.getTextarea();
-    const before = ta.value.slice(0, pos);
-    const fences = (before.match(/```/g) || []).length;
-    return fences % 2 === 1;
-  }
+	function isInCodeBlock(pos: number) {
+		const ta = editorRef.getTextarea();
+		const before = ta.value.slice(0, pos);
+		const fences = (before.match(/```/g) || []).length;
+		return fences % 2 === 1;
+	}
 
-  function safeWrap(p: string, sfx = p) {
-    const ta = editorRef.getTextarea();
-    if (isInCodeBlock(ta.selectionStart)) {
-      ask('Cannot format text inside a code block');
-      return;
-    }
-    editorRef.wrapSelection(p, sfx, '');
-  }
+	function safeWrap(p: string, sfx = p) {
+		const ta = editorRef.getTextarea();
+		if (isInCodeBlock(ta.selectionStart)) {
+			ask('Cannot format text inside a code block');
+			return;
+		}
+		editorRef.wrapSelection(p, sfx, '');
+	}
 
-  function heading(level: number) {
-    const ta = editorRef.getTextarea();
-    const { value, selectionStart: s, selectionEnd: e } = ta;
-    const startLine = value.lastIndexOf('\n', s - 1) + 1;
-    let endLine = value.indexOf('\n', e);
-    if (endLine === -1) endLine = value.length;
-    const lines = value.slice(startLine, endLine).split('\n');
-    const prefix = '#'.repeat(level) + ' ';
+	function heading(level: number) {
+		const ta = editorRef.getTextarea();
+		const { value, selectionStart: s, selectionEnd: e } = ta;
+		const startLine = value.lastIndexOf('\n', s - 1) + 1;
+		let endLine = value.indexOf('\n', e);
+		if (endLine === -1) endLine = value.length;
+		const lines = value.slice(startLine, endLine).split('\n');
+		const prefix = '#'.repeat(level) + ' ';
 
-    const patched = lines
-      .map((ln) => {
-        const stripped = ln.replace(/^#+\s+/, '');
-        if (ln.trim().startsWith(prefix)) return stripped;
-        return prefix + stripped;
-      })
-      .join('\n');
+		const patched = lines
+			.map((ln) => {
+				const stripped = ln.replace(/^#+\s+/, '');
+				if (ln.trim().startsWith(prefix)) return stripped;
+				return prefix + stripped;
+			})
+			.join('\n');
 
-    const next = value.slice(0, startLine) + patched + value.slice(endLine);
-    ta.value = next;
-    markdownContent.set(next);
-    const newEnd = startLine + patched.length;
-    ta.setSelectionRange(newEnd, newEnd);
-    ta.focus();
-  }
+		const next = value.slice(0, startLine) + patched + value.slice(endLine);
+		ta.value = next;
+		markdownContent.set(next);
+		const newEnd = startLine + patched.length;
+		ta.setSelectionRange(newEnd, newEnd);
+		ta.focus();
+	}
 
-  const fmt = {
-    bold:    () => safeWrap('**', '**'),
-    italic:  () => safeWrap('_', '_'),
-    h1:      () => heading(1),
-    h2:      () => heading(2),
-    h3:      () => heading(3),
-    h4:      () => heading(4),
-    h5:      () => heading(5),
-    h6:      () => heading(6),
-    link:    () => editorRef.wrapSelection('[', '](https://)', ''),
-    image:   () => editorRef.insertAtCursor('![alt](https://)', ),
-    codeblk: () => editorRef.wrapSelection('```\n', '\n```', ''),
-    inline:  () => editorRef.wrapSelection('`', '`', 'code'),
-    ul:      () => bullets('- '),
-    ol:      () => bullets('1. ', true),
-    quote:   () => editorRef.wrapSelection('> ', '', ''),
-    hr:      () => editorRef.insertAtCursor('\n---\n')
-  };
+	const fmt = {
+		bold: () => safeWrap('**', '**'),
+		italic: () => safeWrap('_', '_'),
+		h1: () => heading(1),
+		h2: () => heading(2),
+		h3: () => heading(3),
+		h4: () => heading(4),
+		h5: () => heading(5),
+		h6: () => heading(6),
+		link: () => editorRef.wrapSelection('[', '](https://)', ''),
+		image: () => editorRef.insertAtCursor('![alt](https://)'),
+		codeblk: () => editorRef.wrapSelection('```\n', '\n```', ''),
+		inline: () => editorRef.wrapSelection('`', '`', 'code'),
+		ul: () => bullets('- '),
+		ol: () => bullets('1. ', true),
+		quote: () => editorRef.wrapSelection('> ', '', ''),
+		hr: () => editorRef.insertAtCursor('\n---\n')
+	};
 
-  /* ---------------- pane scroll syncing ---------------- */
-  let syncing = false;
-  function sync(source: 'editor' | 'preview') {
-    if (syncing) return;
-    syncing = true;
-    const src = source === 'editor' ? editorPane : previewPane;
-    const tgt = source === 'editor' ? previewPane : editorPane;
-    const ratio = src.scrollTop / (src.scrollHeight - src.clientHeight || 1);
-    tgt.scrollTop = ratio * (tgt.scrollHeight - tgt.clientHeight);
-    syncing = false;
-  }
+	/* ---------------- pane scroll syncing ---------------- */
+	let syncing = false;
+	function sync(source: 'editor' | 'preview') {
+		if (syncing) return;
+		syncing = true;
+		const src = source === 'editor' ? editorPane : previewPane;
+		const tgt = source === 'editor' ? previewPane : editorPane;
+		const ratio = src.scrollTop / (src.scrollHeight - src.clientHeight || 1);
+		tgt.scrollTop = ratio * (tgt.scrollHeight - tgt.clientHeight);
+		syncing = false;
+	}
 
-  function onHighlight(e: CustomEvent<{ line: number | null }>) {
-    editorRef.highlightLine(e.detail.line);
-  }
+	function onHighlight(e: CustomEvent<{ line: number | null }>) {
+		editorRef.highlightLine(e.detail.line);
+	}
 
-  function onJump(e: CustomEvent<{ line: number }>) {
-    editorRef.jumpToLine(e.detail.line);
-  }
+	function onJump(e: CustomEvent<{ line: number }>) {
+		editorRef.jumpToLine(e.detail.line);
+	}
 
-  /* ---------------- session restore ---------------- */
+	/* ---------------- session restore ---------------- */
 
-  onMount(() => {
-    const cached = localStorage.getItem('markdown-editor-content');
-    if (cached) {
-      ask('Load previous session?').then((ok) => {
-        if (ok) markdownContent.set(cached);
-      });
-    }
+	onMount(() => {
+		const cached = localStorage.getItem('markdown-editor-content');
+		if (cached) {
+			ask('Load previous session?').then((ok) => {
+				if (ok) markdownContent.set(cached);
+			});
+		}
 
-    window.addEventListener('beforeunload', (e) => {
-      if (get(dirty)) {
-        e.preventDefault();
-        e.returnValue = '';
-      }
-    });
-  });
+		window.addEventListener('beforeunload', (e) => {
+			if (get(dirty)) {
+				e.preventDefault();
+				e.returnValue = '';
+			}
+		});
+	});
 </script>
 
 <!-- hidden input fallback -->
 <input
-  type="file"
-  accept=".md,.markdown,text/markdown"
-  bind:this={hiddenInput}
-  on:change={handleFile}
-  style="display:none"
+	type="file"
+	accept=".md,.markdown,text/markdown"
+	bind:this={hiddenInput}
+	on:change={handleFile}
+	style="display:none"
 />
 
 <!-- optional metadata panel -->
 {#if showMeta}
-  <MetadataPanel closePanel={() => (showMeta = false)} />
+	<MetadataPanel closePanel={() => (showMeta = false)} />
 {/if}
 
-<Toolbar
-  onOpen={onOpen}
-  onSave={onSave}
-  fmt={fmt}
-  showMetaPanel={() => (showMeta = !showMeta)}
-/>
+<Toolbar {onOpen} {onSave} {fmt} showMetaPanel={() => (showMeta = !showMeta)} />
 
 <div class="editor-layout">
-  <div
-    class="pane editor-pane"
-    bind:this={editorPane}
-    on:scroll={() => sync('editor')}
-  >
-    <MarkdownEditor bind:this={editorRef} />
-  </div>
-  <div
-    class="pane preview-pane"
-    bind:this={previewPane}
-    on:scroll={() => sync('preview')}
-  >
-    <MarkdownPreview on:highlight={onHighlight} on:jump={onJump} />
-  </div>
+	<div class="pane editor-pane" bind:this={editorPane} on:scroll={() => sync('editor')}>
+		<MarkdownEditor bind:this={editorRef} />
+	</div>
+	<div class="pane preview-pane" bind:this={previewPane} on:scroll={() => sync('preview')}>
+		<MarkdownPreview on:highlight={onHighlight} on:jump={onJump} />
+	</div>
 </div>
 {#if confirmMsg}
-  <ConfirmDialog message={confirmMsg} onConfirm={handleConfirm} />
+	<ConfirmDialog message={confirmMsg} onConfirm={handleConfirm} />
 {/if}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,103 +2,108 @@
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
 }
 html,
 body {
-  height: 100%;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+	height: 100%;
+	font-family:
+		system-ui,
+		-apple-system,
+		'Segoe UI',
+		Roboto,
+		sans-serif;
 }
 
 /* -------- CSS variables -------- */
 :root {
-  /* palette */
-  --bg-light: #ffffff;
-  --text-light: #222;
-  --bg-dark: #1e1e1e;
-  --text-dark: #ddd;
-  --border: #c9c9c9;
-  --accent: #0d6efd;
+	/* palette */
+	--bg-light: #ffffff;
+	--text-light: #222;
+	--bg-dark: #1e1e1e;
+	--text-dark: #ddd;
+	--border: #c9c9c9;
+	--accent: #0d6efd;
 
-  /* misc */
-  --mono: ui-monospace, "Courier New", monospace;
-  --transition: 0.2s ease-in-out;
+	/* misc */
+	--mono: ui-monospace, 'Courier New', monospace;
+	--transition: 0.2s ease-in-out;
 }
 
 .line-numbers {
-  background: rgba(0, 0, 0, 0.04);
-  line-height: 1.5;
+	background: rgba(0, 0, 0, 0.04);
+	line-height: 1.5;
 }
 .line-numbers div {
-  height: 1.5em;
+	height: 1.5em;
 }
 html.dark .line-numbers {
-  background: rgba(255, 255, 255, 0.05);
+	background: rgba(255, 255, 255, 0.05);
 }
 
 /* light / dark bodies */
 html.light body {
-  background: var(--bg-light);
-  color: var(--text-light);
+	background: var(--bg-light);
+	color: var(--text-light);
 }
 html.dark body {
-  background: var(--bg-dark);
-  color: var(--text-dark);
+	background: var(--bg-dark);
+	color: var(--text-dark);
 }
 
 /* -------- layout container -------- */
 .editor-layout {
-  display: flex;
-  height: calc(100vh - 52px); /* header height */
-  overflow: hidden;
+	display: flex;
+	height: calc(100vh - 52px); /* header height */
+	overflow: hidden;
 }
 @media (max-width: 767px) {
-  .editor-layout {
-    flex-direction: column;
-    height: auto;
-  }
+	.editor-layout {
+		flex-direction: column;
+		height: auto;
+	}
 }
 
 /* pane basics */
 .pane {
-  flex: 1;
-  padding: 1rem;
-  overflow: auto;
+	flex: 1;
+	padding: 1rem;
+	overflow: auto;
 }
 .preview-pane {
-  scrollbar-width: none; /* Firefox */
+	scrollbar-width: none; /* Firefox */
 }
 .preview-pane::-webkit-scrollbar {
-  display: none;
+	display: none;
 }
 .pane + .pane {
-  border-left: 1px solid var(--border);
+	border-left: 1px solid var(--border);
 }
 @media (max-width: 767px) {
-  .pane + .pane {
-    border-left: none;
-    border-top: 1px solid var(--border);
-  }
+	.pane + .pane {
+		border-left: none;
+		border-top: 1px solid var(--border);
+	}
 }
 
 /* -------- textarea -------- */
 textarea {
-  width: 100%;
-  height: 100%;
-  border: none;
-  resize: none;
-  font-family: var(--mono);
-  background: inherit;
-  color: inherit;
-  line-height: 1.5;
-  outline: none;
+	width: 100%;
+	height: 100%;
+	border: none;
+	resize: none;
+	font-family: var(--mono);
+	background: inherit;
+	color: inherit;
+	line-height: 1.5;
+	outline: none;
 }
 
 /* -------- markdown preview styling -------- */
 .preview-content {
-  line-height: 1.5;
+	line-height: 1.5;
 }
 .preview-content h1,
 .preview-content h2,
@@ -106,92 +111,108 @@ textarea {
 .preview-content h4,
 .preview-content h5,
 .preview-content h6 {
-  margin: 1rem 0 0.5rem;
-  font-weight: 700;
+	margin: 1rem 0 0.5rem;
+	font-weight: 700;
 }
 
-.preview-content h1 { font-size: 2rem; }
-.preview-content h2 { font-size: 1.75rem; }
-.preview-content h3 { font-size: 1.5rem; }
-.preview-content h4 { font-size: 1.25rem; }
-.preview-content h5 { font-size: 1.1rem; }
-.preview-content h6 { font-size: 1rem; }
+.preview-content h1 {
+	font-size: 2rem;
+}
+.preview-content h2 {
+	font-size: 1.75rem;
+}
+.preview-content h3 {
+	font-size: 1.5rem;
+}
+.preview-content h4 {
+	font-size: 1.25rem;
+}
+.preview-content h5 {
+	font-size: 1.1rem;
+}
+.preview-content h6 {
+	font-size: 1rem;
+}
 .preview-content p,
 .preview-content ul,
 .preview-content ol,
 .preview-content blockquote,
 .preview-content pre,
 .preview-content table {
-  margin: 0.5rem 0;
+	margin: 0.5rem 0;
 }
 
 .preview-content ul,
 .preview-content ol {
-  padding-left: 1.5rem;
-  margin: 0.5rem 0;
-  list-style-position: inside;
+	padding-left: 1.5rem;
+	margin: 0.5rem 0;
+	list-style-position: inside;
 }
 
-.preview-content ul  { list-style-type: disc;   }   /* ● item */
-.preview-content ol  { list-style-type: decimal; }   /* 1. item */
+.preview-content ul {
+	list-style-type: disc;
+} /* ● item */
+.preview-content ol {
+	list-style-type: decimal;
+} /* 1. item */
 
 .preview-content blockquote {
-  border-left: 4px solid var(--border);
-  padding-left: 1rem;
-  color: #666;
+	border-left: 4px solid var(--border);
+	padding-left: 1rem;
+	color: #666;
 }
 html.dark .preview-content blockquote {
-  color: #aaa;
-  border-color: #444;
+	color: #aaa;
+	border-color: #444;
 }
 .preview-content code {
-  background: #f5f5f5;
-  padding: 2px 4px;
-  border-radius: 4px;
-  font-family: var(--mono);
+	background: #f5f5f5;
+	padding: 2px 4px;
+	border-radius: 4px;
+	font-family: var(--mono);
 }
 html.dark .preview-content code {
-  background: #323232;
+	background: #323232;
 }
 .preview-content pre {
-  background: #f5f5f5;
-  padding: 0.75rem;
-  border-radius: 6px;
-  overflow-x: auto;
+	background: #f5f5f5;
+	padding: 0.75rem;
+	border-radius: 6px;
+	overflow-x: auto;
 }
 .preview-content [data-line]:hover {
-  background: rgba(180, 180, 180, 0.15);
+	background: rgba(180, 180, 180, 0.15);
 }
 html.dark .preview-content [data-line]:hover {
-  background: rgba(255, 255, 255, 0.08);
+	background: rgba(255, 255, 255, 0.08);
 }
 html.dark .preview-content pre {
-  background: #2b2b2b;
+	background: #2b2b2b;
 }
 
 /* --- tables --- */
 .preview-content table {
-  border-collapse: collapse;
-  width: 100%;
-  margin: 0.5rem 0;
+	border-collapse: collapse;
+	width: 100%;
+	margin: 0.5rem 0;
 }
 .preview-content th,
 .preview-content td {
-  border: 1px solid var(--border);
-  padding: 0.4rem 0.6rem;
-  text-align: left;
+	border: 1px solid var(--border);
+	padding: 0.4rem 0.6rem;
+	text-align: left;
 }
 
 /* --- task list checkboxes --- */
-.preview-content input[type="checkbox"] {
-  margin-right: 0.4rem;
+.preview-content input[type='checkbox'] {
+	margin-right: 0.4rem;
 }
 
 /* --- highlight ==mark== --- */
 .preview-content mark {
-  background: #fff59b;
-  padding: 0 0.15em;
+	background: #fff59b;
+	padding: 0 0.15em;
 }
 html.dark .preview-content mark {
-  background: #7d6b00;
+	background: #7d6b00;
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter(),
-		alias:{
+		alias: {
 			$lib: 'src/lib',
 			$components: 'src/components',
 			$stores: 'src/stores',
@@ -29,7 +29,7 @@ const config = {
 			$constants: 'src/constants',
 			$helpers: 'src/helpers',
 			$plugins: 'src/plugins',
-			$theme: 'src/theme',
+			$theme: 'src/theme'
 		}
 	}
 };

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -2,29 +2,29 @@ import { describe, it, expect } from 'vitest';
 import { parseFrontMatter, buildFrontMatter } from '../src/lib/utils';
 
 describe('parseFrontMatter', () => {
-  it('parses YAML front matter when present', () => {
-    const input = `---\ntitle: "Post"\ntags: [foo, bar]\n---\nBody text`;
-    const result = parseFrontMatter(input);
-    expect(result).not.toBeNull();
-    expect(result?.meta).toEqual({ title: 'Post', tags: ['foo', 'bar'] });
-    expect(result?.body).toBe('Body text');
-  });
+	it('parses YAML front matter when present', () => {
+		const input = `---\ntitle: "Post"\ntags: [foo, bar]\n---\nBody text`;
+		const result = parseFrontMatter(input);
+		expect(result).not.toBeNull();
+		expect(result?.meta).toEqual({ title: 'Post', tags: ['foo', 'bar'] });
+		expect(result?.body).toBe('Body text');
+	});
 
-  it('returns null when no front matter found', () => {
-    const input = 'Just body';
-    expect(parseFrontMatter(input)).toBeNull();
-  });
+	it('returns null when no front matter found', () => {
+		const input = 'Just body';
+		expect(parseFrontMatter(input)).toBeNull();
+	});
 });
 
 describe('buildFrontMatter', () => {
-  it('creates a YAML block with trailing newline', () => {
-    const yaml = buildFrontMatter({
-      title: 'A',
-      author: 'B',
-      date: '2024-01-01',
-      tags: ['x', 'y']
-    });
-    const expected = `---\ntitle: "A"\nauthor: "B"\ndate: "2024-01-01"\ntags: [\"x\", \"y\"]\n---\n`;
-    expect(yaml).toBe(expected);
-  });
+	it('creates a YAML block with trailing newline', () => {
+		const yaml = buildFrontMatter({
+			title: 'A',
+			author: 'B',
+			date: '2024-01-01',
+			tags: ['x', 'y']
+		});
+		const expected = `---\ntitle: "A"\nauthor: "B"\ndate: "2024-01-01"\ntags: ["x", "y"]\n---\n`;
+		expect(yaml).toBe(expected);
+	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,18 +11,8 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	},
-	"include": [
-		"src/**/*",
-		"@types/**/*.d.ts"
-	],
-	"exclude": [
-		"node_modules",
-		"build",
-		"dist",
-		"public",
-		".svelte-kit",
-		"*.config.js"
-	],
+	"include": ["src/**/*", "@types/**/*.d.ts"],
+	"exclude": ["node_modules", "build", "dist", "public", ".svelte-kit", "*.config.js"]
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
## Summary
- satisfy linter rules across the project
- refine metadata panel title field
- sanitize toolbar button text
- prevent DOM warning in `MarkdownEditor`
- use safer types in utils and stores
- add file picker typings in page logic
- tweak expected string in utils test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841f339c3c88326ae9357fe06d7e0a0