### PR TITLE
Fix lint issues and adjust title field

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 SvelteKit‑based web app for live Markdown editing and previewing.
 
-[![Vercel Deployment](https://vercelbadge.vercel.app/api/binesh-b0/markdown-editor)](https://markdown-editor-iota-seven.vercel.app/)	[![SvelteKit](https://img.shields.io/badge/SvelteKit-%23f1413d.svg?logo=svelte&logoColor=white)](#)
+[![Vercel Deployment](https://vercelbadge.vercel.app/api/binesh-b0/markdown-editor)](https://markdown-editor-iota-seven.vercel.app/) [![SvelteKit](https://img.shields.io/badge/SvelteKit-%23f1413d.svg?logo=svelte&logoColor=white)](#)
 
 [View Live Demo](https://markdown-editor-iota-seven.vercel.app/)
 
 ![Screenshot](docs/Screenshot.png)
 
 ---
+
 ## Installation & Setup
 
 Clone the repository and install:
+
 ```bash
 git clone <repo-url>
 cd markdown-editor
@@ -19,6 +21,7 @@ npm install
 ```
 
 Start the development server:
+
 ```bash
 npm run dev
 ```
@@ -29,5 +32,5 @@ npm run dev
   the page will offer to restore the previous session.
 - Use the **Download** button (⌘‑S) in the toolbar to save the current document
   as a `.md` file. When supported, the native File System API is used.
-- A small *Unsaved* indicator appears in the toolbar whenever edits have not yet
+- A small _Unsaved_ indicator appears in the toolbar whenever edits have not yet
   been downloaded.

--- a/src/components/ConfirmDialog.svelte
+++ b/src/components/ConfirmDialog.svelte
@@ -1,45 +1,47 @@
 <script lang="ts">
-  export let message = '';
-  export let onConfirm: (v: boolean) => void;
+	export let message = '';
+	export let onConfirm: (v: boolean) => void;
 </script>
-<style>
-  .overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0,0,0,0.4);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 50;
-  }
-  .box {
-    background: var(--bg-light);
-    border: 1px solid var(--border);
-    padding: 1rem 1.5rem;
-    border-radius: 6px;
-    min-width: 240px;
-    text-align: center;
-  }
-  html.dark .box {
-    background: var(--bg-dark);
-  }
-  button {
-    margin: 0.5rem;
-    padding: 0.25rem 0.75rem;
-    background: none;
-    border: 1px solid var(--border);
-    cursor: pointer;
-  }
-</style>
+
 <div class="overlay">
-  <div class="box">
-    <div>{message}</div>
-    <div>
-      <button on:click={() => onConfirm(true)}>OK</button>
-      <button on:click={() => onConfirm(false)}>Cancel</button>
-    </div>
-  </div>
+	<div class="box">
+		<div>{message}</div>
+		<div>
+			<button on:click={() => onConfirm(true)}>OK</button>
+			<button on:click={() => onConfirm(false)}>Cancel</button>
+		</div>
+	</div>
 </div>
+
+<style>
+	.overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.4);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 50;
+	}
+	.box {
+		background: var(--bg-light);
+		border: 1px solid var(--border);
+		padding: 1rem 1.5rem;
+		border-radius: 6px;
+		min-width: 240px;
+		text-align: center;
+	}
+	html.dark .box {
+		background: var(--bg-dark);
+	}
+	button {
+		margin: 0.5rem;
+		padding: 0.25rem 0.75rem;
+		background: none;
+		border: 1px solid var(--border);
+		cursor: pointer;
+	}
+</style>

--- a/src/components/MarkdownEditor.svelte
+++ b/src/components/MarkdownEditor.svelte
@@ -1,173 +1,182 @@
 <script lang="ts">
-  import { markdownContent, showLineNumbers } from '$lib/stores';
-  import { onMount, tick } from 'svelte';
-  import { get } from 'svelte/store';
+	import { markdownContent, showLineNumbers } from '$lib/stores';
+	import { onMount, tick } from 'svelte';
+	import { get } from 'svelte/store';
 
-  let textareaEl: HTMLTextAreaElement;
-  let lineNumEl: HTMLElement;
+	let textareaEl: HTMLTextAreaElement;
+	let lineNumEl: HTMLElement;
 
-  function autoSize() {
-    if (textareaEl) {
-      textareaEl.style.height = 'auto';
-      textareaEl.style.height = textareaEl.scrollHeight + 'px';
-      if (lineNumEl) {
-        lineNumEl.style.height = textareaEl.style.height;
-      }
-    }
-  }
- 
-  function updateLines(text: string) {
-    autoSize();
-    if (!get(showLineNumbers) || !lineNumEl) return;
-    const lines = text.split('\n').length || 1;
-    lineNumEl.innerHTML = Array.from({ length: lines }, (_, i) => `<div>${i + 1}</div>`).join('');
-    lineNumEl.style.height = textareaEl ? textareaEl.style.height : 'auto';
-  }
+	function autoSize() {
+		if (textareaEl) {
+			textareaEl.style.height = 'auto';
+			textareaEl.style.height = textareaEl.scrollHeight + 'px';
+			if (lineNumEl) {
+				lineNumEl.style.height = textareaEl.style.height;
+			}
+		}
+	}
 
-  function handleInput(e: Event) {
-    const val = (e.target as HTMLTextAreaElement).value;
-    markdownContent.set(val);
-    updateLines(val);
-  }
+	function updateLines(text: string) {
+		autoSize();
+		if (!get(showLineNumbers) || !lineNumEl) return;
+		const lines = text.split('\n').length || 1;
+		// eslint-disable-next-line svelte/no-dom-manipulating
+		lineNumEl.innerHTML = Array.from({ length: lines }, (_, i) => `<div>${i + 1}</div>`).join('');
+		lineNumEl.style.height = textareaEl ? textareaEl.style.height : 'auto';
+	}
 
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      const { selectionStart: s, selectionEnd: end, value } = textareaEl;
-      const startLine = value.lastIndexOf('\n', s - 1) + 1;
-      let endLine = value.indexOf('\n', end);
-      if (endLine === -1) endLine = value.length;
-      const lines = value.slice(startLine, endLine).split('\n');
+	function handleInput(e: Event) {
+		const val = (e.target as HTMLTextAreaElement).value;
+		markdownContent.set(val);
+		updateLines(val);
+	}
 
-      const patched = lines
-        .map((ln) => {
-          if (e.shiftKey) {
-            if (ln.startsWith('    ')) return ln.slice(4);
-            if (ln.startsWith('\t')) return ln.slice(1);
-            return ln.replace(/^\s{1,4}/, '');
-          }
-          return '    ' + ln;
-        })
-        .join('\n');
+	function handleKeyDown(e: KeyboardEvent) {
+		if (e.key === 'Tab') {
+			e.preventDefault();
+			const { selectionStart: s, selectionEnd: end, value } = textareaEl;
+			const startLine = value.lastIndexOf('\n', s - 1) + 1;
+			let endLine = value.indexOf('\n', end);
+			if (endLine === -1) endLine = value.length;
+			const lines = value.slice(startLine, endLine).split('\n');
 
-      const next = value.slice(0, startLine) + patched + value.slice(endLine);
-      textareaEl.value = next;
-      markdownContent.set(next);
-      const newEnd = startLine + patched.length;
-      textareaEl.setSelectionRange(startLine, newEnd);
-      updateLines(next);
-      return;
-    }
+			const patched = lines
+				.map((ln) => {
+					if (e.shiftKey) {
+						if (ln.startsWith('    ')) return ln.slice(4);
+						if (ln.startsWith('\t')) return ln.slice(1);
+						return ln.replace(/^\s{1,4}/, '');
+					}
+					return '    ' + ln;
+				})
+				.join('\n');
 
-    if (e.key === 'Enter') {
-      const { selectionStart: s, value } = textareaEl;
-      const prevStart = value.lastIndexOf('\n', s - 1) + 1;
-      const prevLine = value.slice(prevStart, s);
-      const olMatch = prevLine.match(/^(\s*)(\d+)\.\s+/);
-      const ulMatch = prevLine.match(/^(\s*)([-*+] )/);
-      if (olMatch) {
-        e.preventDefault();
-        const indent = olMatch[1];
-        const num = Number(olMatch[2]) + 1;
-        const insertion = `\n${indent}${num}. `;
-        insertAtCursor(insertion, 0);
-        return;
-      }
-      if (ulMatch) {
-        e.preventDefault();
-        const indent = ulMatch[1];
-        const bullet = ulMatch[2];
-        const insertion = `\n${indent}${bullet}`;
-        insertAtCursor(insertion, 0);
-        return;
-      }
-    }
-  }
+			const next = value.slice(0, startLine) + patched + value.slice(endLine);
+			textareaEl.value = next;
+			markdownContent.set(next);
+			const newEnd = startLine + patched.length;
+			textareaEl.setSelectionRange(startLine, newEnd);
+			updateLines(next);
+			return;
+		}
 
-  $: (async () => { await tick(); updateLines($markdownContent); })();
-  onMount(() => updateLines($markdownContent));
+		if (e.key === 'Enter') {
+			const { selectionStart: s, value } = textareaEl;
+			const prevStart = value.lastIndexOf('\n', s - 1) + 1;
+			const prevLine = value.slice(prevStart, s);
+			const olMatch = prevLine.match(/^(\s*)(\d+)\.\s+/);
+			const ulMatch = prevLine.match(/^(\s*)([-*+] )/);
+			if (olMatch) {
+				e.preventDefault();
+				const indent = olMatch[1];
+				const num = Number(olMatch[2]) + 1;
+				const insertion = `\n${indent}${num}. `;
+				insertAtCursor(insertion, 0);
+				return;
+			}
+			if (ulMatch) {
+				e.preventDefault();
+				const indent = ulMatch[1];
+				const bullet = ulMatch[2];
+				const insertion = `\n${indent}${bullet}`;
+				insertAtCursor(insertion, 0);
+				return;
+			}
+		}
+	}
 
-  export function highlightLine(line: number | null) {
-    if (!textareaEl || line == null) return;
-    const lines = textareaEl.value.split('\n');
-    const start = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
-    const end = start + lines[line - 1].length;
-    textareaEl.setSelectionRange(start, end);
-  }
+	$: (async () => {
+		await tick();
+		updateLines($markdownContent);
+	})();
+	onMount(() => updateLines($markdownContent));
 
-  export function jumpToLine(line: number) {
-    if (!textareaEl) return;
-    const lines = textareaEl.value.split('\n');
-    const pos = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
-    textareaEl.focus();
-    textareaEl.setSelectionRange(pos, pos);
-  }
+	export function highlightLine(line: number | null) {
+		if (!textareaEl || line == null) return;
+		const lines = textareaEl.value.split('\n');
+		const start = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
+		const end = start + lines[line - 1].length;
+		textareaEl.setSelectionRange(start, end);
+	}
 
-export function wrapSelection(prefix: string, suffix = prefix, placeholder = '') {
-    const { selectionStart: s, selectionEnd: e, value } = textareaEl;
-    const selected = value.slice(s, e) || placeholder;
-    const updated  = value.slice(0, s) + prefix + selected + suffix + value.slice(e);
-    textareaEl.value = updated;
-    markdownContent.set(updated);
+	export function jumpToLine(line: number) {
+		if (!textareaEl) return;
+		const lines = textareaEl.value.split('\n');
+		const pos = lines.slice(0, line - 1).join('\n').length + (line > 1 ? 1 : 0);
+		textareaEl.focus();
+		textareaEl.setSelectionRange(pos, pos);
+	}
 
-    const cursor = s + prefix.length + (selected === placeholder ? 0 : selected.length);
-    textareaEl.focus();
-    textareaEl.setSelectionRange(cursor, cursor);
-  }
+	export function wrapSelection(prefix: string, suffix = prefix, placeholder = '') {
+		const { selectionStart: s, selectionEnd: e, value } = textareaEl;
+		const selected = value.slice(s, e) || placeholder;
+		const updated = value.slice(0, s) + prefix + selected + suffix + value.slice(e);
+		textareaEl.value = updated;
+		markdownContent.set(updated);
 
-export function insertAtCursor(text:string, cursorOffset = 0) {
-    const {selectionStart:s, selectionEnd: e, value } = textareaEl;
-    const updated = value.slice(0, s) + text + value.slice(e);
-    textareaEl.value = updated;
-    markdownContent.set(updated);
-    const cursor = s + text.length + cursorOffset;
-    textareaEl.focus();
-    textareaEl.setSelectionRange(cursor, cursor);
-  }
+		const cursor = s + prefix.length + (selected === placeholder ? 0 : selected.length);
+		textareaEl.focus();
+		textareaEl.setSelectionRange(cursor, cursor);
+	}
 
-export function getTextarea(): HTMLTextAreaElement {
-  return textareaEl;
-}
+	export function insertAtCursor(text: string, cursorOffset = 0) {
+		const { selectionStart: s, selectionEnd: e, value } = textareaEl;
+		const updated = value.slice(0, s) + text + value.slice(e);
+		textareaEl.value = updated;
+		markdownContent.set(updated);
+		const cursor = s + text.length + cursorOffset;
+		textareaEl.focus();
+		textareaEl.setSelectionRange(cursor, cursor);
+	}
+
+	export function getTextarea(): HTMLTextAreaElement {
+		return textareaEl;
+	}
 </script>
-<style>
-  .editor-wrap {
-    display: flex;
-    height: 100%;
-  }
-  .line-numbers {
-    user-select: none;
-    text-align: right;
-    padding: 0.5rem 0.75rem 0.5rem 0.25rem;
-    border-right: 1px solid var(--border);
-    font-family: var(--mono);
-    opacity: 0.6;
-    border-radius: var(--radius) 0 0 var(--radius);
-  }
-  textarea {
-    flex: 1;
-    padding: 0.5rem 0.75rem;
-    border: none;
-    resize: none;
-    overflow-y: hidden;
-    height: auto;
-    white-space: pre;
-    border-radius: var(--radius);
-    font-family: var(--mono);
-    line-height: 1.5;
-    background: inherit;
-    color: inherit;
-    outline: none;
-  }
-</style>
+
 <!-- textarea automatically bound via store subscription -->
-<div class = "editor-wrap">
-    <pre class="line-numbers" bind:this={lineNumEl} style="display: {$showLineNumbers ? 'block' : 'none'}"></pre>
-    <textarea
-  bind:this={textareaEl}
-  bind:value={$markdownContent}
-  on:input={handleInput}
-  on:keydown={handleKeyDown}
-  spellcheck="false"
-  placeholder="# Start typing Markdown..."
-></textarea>
+<div class="editor-wrap">
+	<pre
+		class="line-numbers"
+		bind:this={lineNumEl}
+		style="display: {$showLineNumbers ? 'block' : 'none'}"></pre>
+	<textarea
+		bind:this={textareaEl}
+		bind:value={$markdownContent}
+		on:input={handleInput}
+		on:keydown={handleKeyDown}
+		spellcheck="false"
+		placeholder="# Start typing Markdown..."
+	></textarea>
 </div>
+
+<style>
+	.editor-wrap {
+		display: flex;
+		height: 100%;
+	}
+	.line-numbers {
+		user-select: none;
+		text-align: right;
+		padding: 0.5rem 0.75rem 0.5rem 0.25rem;
+		border-right: 1px solid var(--border);
+		font-family: var(--mono);
+		opacity: 0.6;
+		border-radius: var(--radius) 0 0 var(--radius);
+	}
+	textarea {
+		flex: 1;
+		padding: 0.5rem 0.75rem;
+		border: none;
+		resize: none;
+		overflow-y: hidden;
+		height: auto;
+		white-space: pre;
+		border-radius: var(--radius);
+		font-family: var(--mono);
+		line-height: 1.5;
+		background: inherit;
+		color: inherit;
+		outline: none;
+	}
+</style>

--- a/src/components/MarkdownPreview.svelte
+++ b/src/components/MarkdownPreview.svelte
@@ -1,28 +1,28 @@
 <script lang="ts">
-  import { htmlContent } from '$lib/stores';
-  import { createEventDispatcher } from 'svelte';
+	import { htmlContent } from '$lib/stores';
+	import { createEventDispatcher } from 'svelte';
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  function onHover(event: MouseEvent) {
-    const el = (event.target as HTMLElement).closest('[data-line]');
-    dispatch('highlight', { line: el ? Number(el.getAttribute('data-line')) : null });
-  }
+	function onHover(event: MouseEvent) {
+		const el = (event.target as HTMLElement).closest('[data-line]');
+		dispatch('highlight', { line: el ? Number(el.getAttribute('data-line')) : null });
+	}
 
-  function onClick(event: MouseEvent) {
-    const el = (event.target as HTMLElement).closest('[data-line]');
-    if (el) dispatch('jump', { line: Number(el.getAttribute('data-line')) });
-  }
+	function onClick(event: MouseEvent) {
+		const el = (event.target as HTMLElement).closest('[data-line]');
+		if (el) dispatch('jump', { line: Number(el.getAttribute('data-line')) });
+	}
 </script>
 
 <div
-  class="preview-content"
-  on:mouseover={onHover}
-  on:mouseleave={() => dispatch('highlight', { line: null })}
-  on:click={onClick}
-  role="notebook"
-  tabindex="0"
-  on:focus={() => dispatch('highlight', { line: null })}
+	class="preview-content"
+	on:mouseover={onHover}
+	on:mouseleave={() => dispatch('highlight', { line: null })}
+	on:click={onClick}
+	role="notebook"
+	tabindex="0"
+	on:focus={() => dispatch('highlight', { line: null })}
 >
-  {@html $htmlContent}
+	{@html $htmlContent}<!-- eslint-disable-line svelte/no-at-html-tags -->
 </div>

--- a/src/components/MetadataPanel.svelte
+++ b/src/components/MetadataPanel.svelte
@@ -1,93 +1,91 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { markdownContent, dirty, markSaved } from '$lib/stores';
-  import { parseFrontMatter, buildFrontMatter } from '$lib/utils';
-  import { get } from 'svelte/store';
+	import { onMount } from 'svelte';
+	import { markdownContent, markSaved } from '$lib/stores';
+	import { parseFrontMatter, buildFrontMatter } from '$lib/utils';
+	import { get } from 'svelte/store';
 
-  export let closePanel: () => void;
+	export let closePanel: () => void;
 
-  /* form fields */
-  let title = '';
-  let author = '';
-  let date = '';
-  let tags = '';
+	/* form fields */
+	let title = '';
+	let author = '';
+	let date = '';
+	let tags = '';
 
-  /* ─── initial load: pull existing YAML (if any) ─── */
-  onMount(() => {
-    const parsed = parseFrontMatter(get(markdownContent));
-    if (parsed) {
-      const { meta, body } = parsed;
-      title  = (meta.title  ?? '') as string;
-      author = (meta.author ?? '') as string;
-      date   = (meta.date   ?? '') as string;
-      tags   = Array.isArray(meta.tags)
-        ? (meta.tags as string[]).join(', ')
-        : (meta.tags ?? '');
-      markdownContent.set(body);   // buffer now holds *body only*
-    }
-  });
+	/* ─── initial load: pull existing YAML (if any) ─── */
+	onMount(() => {
+		const parsed = parseFrontMatter(get(markdownContent));
+		if (parsed) {
+			const { meta, body } = parsed;
+			title = (meta.title ?? '') as string;
+			author = (meta.author ?? '') as string;
+			date = (meta.date ?? '') as string;
+			tags = Array.isArray(meta.tags) ? (meta.tags as string[]).join(', ') : (meta.tags ?? '');
+			markdownContent.set(body); // buffer now holds *body only*
+		}
+	});
 
-  /* ─── whenever any input changes, rebuild YAML once ─── */
-  $: {
-    /* turn "tag1, tag2" → ["tag1","tag2"] */
-    const tagArr = tags
-      .split(',')
-      .map((t) => t.trim())
-      .filter(Boolean);
+	/* ─── whenever any input changes, rebuild YAML once ─── */
+	$: {
+		/* turn "tag1, tag2" → ["tag1","tag2"] */
+		const tagArr = tags
+			.split(',')
+			.map((t) => t.trim())
+			.filter(Boolean);
 
-    const yaml  = buildFrontMatter({ title, author, date, tags: tagArr });
-    const buf   = get(markdownContent);
-    const body  = parseFrontMatter(buf)?.body ?? buf;   // strip existing YAML if present
-    const next  = `${yaml}${body}`;
+		const yaml = buildFrontMatter({ title, author, date, tags: tagArr });
+		const buf = get(markdownContent);
+		const body = parseFrontMatter(buf)?.body ?? buf; // strip existing YAML if present
+		const next = `${yaml}${body}`;
 
-    if (next !== buf) {
-      markdownContent.set(next);
-      markSaved(next);
-    }
-  }
+		if (next !== buf) {
+			markdownContent.set(next);
+			markSaved(next);
+		}
+	}
 </script>
 
-<style>
-  .panel {
-    border-bottom: 1px solid var(--border);
-    padding: 0.75rem 1rem;
-    display: grid;
-    gap: 0.5rem;
-    background: rgba(0, 0, 0, 0.02);
-  }
-  input {
-    padding: 0.3rem 0.5rem;
-    border: 1px solid var(--border);
-    background: inherit;
-    color: inherit;
-  }
-  button {
-    justify-self: start;
-    margin-top: 0.5rem;
-    background: none;
-    border: 1px solid var(--border);
-    padding: 0.25rem 0.6rem;
-    cursor: pointer;
-  }
-</style>
-
 <div class="panel">
-  <label>
-    Title
-    <input type="text" bind:value={title} />
-  </label>
-  <label>
-    Author
-    <input type="text" bind:value={author} />
-  </label>
-  <label>
-    Date
-    <input type="date" bind:value={date} />
-  </label>
-  <label>
-    Tags (comma‑separated)
-    <input type="text" bind:value={tags} />
-  </label>
+	<label>
+		Title
+		<input type="text" bind:value={title} />
+	</label>
+	<label>
+		Author
+		<input type="text" bind:value={author} />
+	</label>
+	<label>
+		Date
+		<input type="date" bind:value={date} />
+	</label>
+	<label>
+		Tags (comma-separated)
+		<input type="text" bind:value={tags} />
+	</label>
 
-  <button on:click={closePanel}>✓ Done</button>
+	<button on:click={closePanel}>✓ Done</button>
 </div>
+
+<style>
+	.panel {
+		border-bottom: 1px solid var(--border);
+		padding: 0.75rem 1rem;
+		display: grid;
+		gap: 0.5rem;
+		background: rgba(0, 0, 0, 0.02);
+	}
+	input {
+		padding: 0.3rem 0.5rem;
+		border: 1px solid var(--border);
+		background: inherit;
+		color: inherit;
+	}
+	button {
+		justify-self: start;
+		margin-top: 0.5rem;
+		background: none;
+		border: 1px solid var(--border);
+		padding: 0.25rem 0.6rem;
+		cursor: pointer;
+	}
+</style>

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -7,10 +7,13 @@
 	export let fmt: Record<string, () => void>;
 	export let showMetaPanel: () => void;
 
-        /* menu toggle flags */
-        let menuOpen = false;
-        let headOpen = false;
-        let advOpen = false;
+	/* menu toggle flags */
+	let menuOpen = false;
+	let headOpen = false;
+	let advOpen = false;
+
+	// width of filename input adapts to content length
+	$: size = Math.max($fileName.length, 1);
 
 	function toggleTheme() {
 		theme.update((t) => (t === 'light' ? 'dark' : 'light'));
@@ -23,14 +26,15 @@
 
 <div class="toolbar" role="toolbar" aria-label="Editor toolbar">
 	<!-- File -->
-	<button on:click={onOpen} title="Open (⌘‑O)" aria-label="Open file">📂 Open</button>
-	<button on:click={onSave} title="Download (⌘‑S)" aria-label="Download file">💾 Download</button>
+	<button on:click={onOpen} title="Open (⌘-O)" aria-label="Open file">📂 Open</button>
+	<button on:click={onSave} title="Download (⌘-S)" aria-label="Download file">💾 Download</button>
 	<input
 		class="filename"
 		type="text"
 		bind:value={$fileName}
 		aria-label="File name"
 		placeholder="Untitled"
+		{size}
 	/>
 
 	<div class="group-divider"></div>
@@ -92,18 +96,18 @@
 	<button on:click={fmt.codeblk} title="Code block ```">⎇</button>
 	<button on:click={fmt.inline} title="Inline code `code`">⌘</button>
 	<button on:click={fmt.ul} title="• List">•</button>
-	<button on:click={fmt.ol} title="1. List">1.</button>
-	<button on:click={fmt.quote} title="> Quote">❝</button>
+	<button on:click={fmt.ol} title="1. List">1.</button>
+	<button on:click={fmt.quote} title="> Quote">❝</button>
 	<button on:click={fmt.hr} title="Horizontal rule ---">—</button>
-        <div class="menu">
-                <button
-                        on:click={() => (advOpen = !advOpen)}
-                        class="advanced-btn"
-                        aria-haspopup="true"
-                        aria-expanded={advOpen}
-                        aria-label="Advanced formatting"
-                >Advanced ▾</button>
-                {#if advOpen}
+	<div class="menu">
+		<button
+			on:click={() => (advOpen = !advOpen)}
+			class="advanced-btn"
+			aria-haspopup="true"
+			aria-expanded={advOpen}
+			aria-label="Advanced formatting">Advanced ▾</button
+		>
+		{#if advOpen}
 			<div
 				class="dropdown"
 				on:mouseleave={() => (advOpen = false)}
@@ -139,14 +143,14 @@
 	<button on:click={toggleTheme} title="Toggle theme" aria-label="Toggle theme">
 		{#if $theme === 'light'}🌙{:else}🌞{/if}
 	</button>
-        <button
-                on:click={toggleLines}
-                class="line-toggle"
-                aria-label="Toggle line numbers"
-                aria-pressed={$showLineNumbers}
-        >
-                {#if $showLineNumbers}Hide line numbers{:else}Show line numbers{/if}
-        </button>
+	<button
+		on:click={toggleLines}
+		class="line-toggle"
+		aria-label="Toggle line numbers"
+		aria-pressed={$showLineNumbers}
+	>
+		{#if $showLineNumbers}Hide line numbers{:else}Show line numbers{/if}
+	</button>
 
 	<!-- kebab -->
 	<div class="menu">
@@ -163,21 +167,21 @@
 					on:click={() => {
 						menuOpen = false;
 						showMetaPanel();
-					}}>📝 Metadata</button
+					}}>📝 Metadata</button
 				>
 			</div>
 		{/if}
 	</div>
 
 	<!-- Dirty flag -->
-        {#if $dirty}
-                <span
-                        class="unsaved-dot"
-                        aria-label="Unsaved changes"
-                        title="Unsaved changes"
-                        aria-live="polite"
-                ></span>
-        {/if}
+	{#if $dirty}
+		<span
+			class="unsaved-dot"
+			aria-label="Unsaved changes"
+			title="Unsaved changes"
+			aria-live="polite"
+		></span>
+	{/if}
 </div>
 
 <!-- svelte-ignore css_unused_selector -->
@@ -198,19 +202,19 @@
 		background: linear-gradient(135deg, #2b2b2b, #363636);
 		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 	}
-        .toolbar button {
-                background: none;
-                border: none;
-                font-size: 1rem;
-                cursor: pointer;
-                padding: 0.25rem 0.5rem;
-                border-radius: var(--radius);
-                transition: background var(--transition);
-        }
-        .line-toggle,
-        .advanced-btn {
-                font-size: 0.9rem;
-        }
+	.toolbar button {
+		background: none;
+		border: none;
+		font-size: 1rem;
+		cursor: pointer;
+		padding: 0.25rem 0.5rem;
+		border-radius: var(--radius);
+		transition: background var(--transition);
+	}
+	.line-toggle,
+	.advanced-btn {
+		font-size: 0.9rem;
+	}
 	.toolbar button:hover {
 		background: rgba(0, 0, 0, 0.05);
 	}
@@ -224,12 +228,16 @@
 		margin: 0 0.25rem;
 	}
 	.filename {
-		flex: 1 1 120px;
-		min-width: 100px;
+		flex: none;
+		min-width: 0;
 		padding: 0.25rem 0.5rem;
-		border: 1px solid var(--border);
+		border: none;
 		background: inherit;
 		color: inherit;
+	}
+	.filename:focus {
+		outline: none;
+		border-bottom: 1px solid var(--border);
 	}
 	.unsaved-dot {
 		margin-left: auto;
@@ -264,20 +272,20 @@
 		text-align: left;
 		padding: 0.4rem 0.75rem;
 	}
-        @media (max-width: 600px) {
-                .toolbar {
-                        flex-direction: column;
-                        align-items: stretch;
-                        gap: 0.5rem;
-                }
-                .group-divider {
-                        width: 100%;
-                        height: 1px;
-                        margin: 0.25rem 0;
-                }
-                .unsaved-dot {
-                        align-self: flex-end;
-                        margin-left: 0;
-                }
-        }
+	@media (max-width: 600px) {
+		.toolbar {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.5rem;
+		}
+		.group-divider {
+			width: 100%;
+			height: 1px;
+			margin: 0.25rem 0;
+		}
+		.unsaved-dot {
+			align-self: flex-end;
+			margin-left: 0;
+		}
+	}
 </style>

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -3,46 +3,45 @@ import hljs from 'highlight.js';
 
 import mkfootnote from 'markdown-it-footnote';
 // import mkdeflist from 'markdown-it-deflist';
-import { full as emoji } from 'markdown-it-emoji'
+import { full as emoji } from 'markdown-it-emoji';
 // import mkmark from 'markdown-it-mark';
 // import mksub from 'markdown-it-sub';
 // import mksup from 'markdown-it-sup';
 // import mktask from 'markdown-it-task-lists';
-import mkanchor from 'markdown-it-anchor';
 // helper to annotate blocks with source line numbers
 function lineNumbers(md: MarkdownIt) {
-  md.core.ruler.after('block', 'line-numbers', (state) => {
-    state.tokens.forEach((t) => {
-      if (t.map && t.type.endsWith('_open')) {
-        t.attrSet('data-line', String(t.map[0] + 1));
-      }
-    });
-  });
+	md.core.ruler.after('block', 'line-numbers', (state) => {
+		state.tokens.forEach((t) => {
+			if (t.map && t.type.endsWith('_open')) {
+				t.attrSet('data-line', String(t.map[0] + 1));
+			}
+		});
+	});
 }
 export const md: MarkdownIt = new MarkdownIt({
-    html: true,
-    linkify: true,
-    typographer: true,
-    highlight:(code:string,lang:string) => {
-        if (lang && hljs.getLanguage(lang)) {
-            try{
-                return `<pre class="hljs"><code>${
-                hljs.highlight(code, { language: lang }).value
-                }</code></pre>`;
-            } catch {
-                console.log(`Error highlighting code with language ${lang}`);
-            }
-        }
-         return `<pre class="hljs"><code>${md.utils.escapeHtml(code)}</code></pre>`;
-    }
+	html: true,
+	linkify: true,
+	typographer: true,
+	highlight: (code: string, lang: string) => {
+		if (lang && hljs.getLanguage(lang)) {
+			try {
+				return `<pre class="hljs"><code>${
+					hljs.highlight(code, { language: lang }).value
+				}</code></pre>`;
+			} catch {
+				console.log(`Error highlighting code with language ${lang}`);
+			}
+		}
+		return `<pre class="hljs"><code>${md.utils.escapeHtml(code)}</code></pre>`;
+	}
 })
- // Footnotes: [^1], etc.
-  .use(mkfootnote)
-//   // Definition lists: term\n: definition
-//   .use(mkdeflist)
-//   // Emoji shortcodes like :joy:
-  .use(emoji)
-  .use(lineNumbers)
+	// Footnotes: [^1], etc.
+	.use(mkfootnote)
+	//   // Definition lists: term\n: definition
+	//   .use(mkdeflist)
+	//   // Emoji shortcodes like :joy:
+	.use(emoji)
+	.use(lineNumbers);
 //   // ==highlight==
 //   .use(mkmark)
 //   // Subscript: H~2~O
@@ -50,23 +49,7 @@ export const md: MarkdownIt = new MarkdownIt({
 //   // Superscript: X^2^
 //   .use(mksup)
 //   // Task lists: - [ ] or - [x]
-//   .use(mktask, { enabled: true })
-//   // Heading anchors: ### Title {#custom-id}
-  // .use(mkanchor, {
-  //   // let `{#my-id}` syntax work
-  //   permalink: mkanchor.permalink.linkInsideHeader({
-  //     symbol: '¶',
-  //     placement: 'after'
-  //   }),
-  //   slugify: (s: string) =>
-  //     encodeURIComponent(
-  //       String(s)
-  //         .trim()
-  //         .toLowerCase()
-  //         .replace(/\s+/g, '-')
-  //     )
-  // });
 
 export function renderMarkdown(markdown: string): string {
-    return md.render(markdown);
+	return md.render(markdown);
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -23,7 +23,9 @@ export function markSaved(val: string) {
 
 const savedTheme =
 	typeof localStorage !== 'undefined' ? localStorage.getItem('markdown-editor-theme') : null;
-export const theme = writable<'light' | 'dark'>((savedTheme as any) ?? 'light');
+export const theme = writable<'light' | 'dark'>(
+	savedTheme === 'dark' || savedTheme === 'light' ? (savedTheme as 'light' | 'dark') : 'light'
+);
 
 /* ------------ file name ------------ */
 const savedName =

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,10 @@
 /** Simple debounce (used for throttled localStorage writes) */
-export function debounce<T extends (...a: any[]) => void>(fn: T, wait = 500): T {
-  let id: ReturnType<typeof setTimeout>;
-  return ((...args: any[]) => {
-    clearTimeout(id);
-    id = setTimeout(() => fn(...args), wait);
-  }) as T;
+export function debounce<T extends (...a: unknown[]) => void>(fn: T, wait = 500): T {
+	let id: ReturnType<typeof setTimeout>;
+	return ((...args: unknown[]) => {
+		clearTimeout(id);
+		id = setTimeout(() => fn(...args), wait);
+	}) as T;
 }
 /* -------------------------------------------------------------------
    YAML front‑matter helpers
@@ -24,49 +24,48 @@ export function debounce<T extends (...a: any[]) => void>(fn: T, wait = 500): T 
  *   - item2   <- (indented list not supported here)
  */
 export function parseFrontMatter(text: string): {
-  meta: Record<string, string | string[]>;
-  body: string;
+	meta: Record<string, string | string[]>;
+	body: string;
 } | null {
-  if (!text.startsWith('---')) return null;
-  const end = text.indexOf('\n---', 3);
-  if (end === -1) return null;
+	if (!text.startsWith('---')) return null;
+	const end = text.indexOf('\n---', 3);
+	if (end === -1) return null;
 
-  const yaml = text.slice(3, end).trim();
-  const meta: Record<string, any> = {};
+	const yaml = text.slice(3, end).trim();
+	const meta: Record<string, string | string[]> = {};
 
-  yaml.split('\n').forEach((line) => {
-    const [k, ...raw] = line.split(':');
-    if (!k || raw.length === 0) return;
-    const v = raw.join(':').trim();
-    if (v.startsWith('[') && v.endsWith(']')) {
-      meta[k.trim()] = v
-        .slice(1, -1)
-        .split(',')
-        .map((s) => s.trim().replace(/^['"]|['"]$/g, ''));
-    } else {
-      meta[k.trim()] = v.replace(/^['"]|['"]$/g, '');
-    }
-  });
+	yaml.split('\n').forEach((line) => {
+		const [k, ...raw] = line.split(':');
+		if (!k || raw.length === 0) return;
+		const v = raw.join(':').trim();
+		if (v.startsWith('[') && v.endsWith(']')) {
+			meta[k.trim()] = v
+				.slice(1, -1)
+				.split(',')
+				.map((s) => s.trim().replace(/^['"]|['"]$/g, ''));
+		} else {
+			meta[k.trim()] = v.replace(/^['"]|['"]$/g, '');
+		}
+	});
 
-  const body = text.slice(end + 4).replace(/^\s+/, ''); // trim leading newlines
-  return { meta, body };
+	const body = text.slice(end + 4).replace(/^\s+/, ''); // trim leading newlines
+	return { meta, body };
 }
 
 /**
  * buildFrontMatter — serialises fields into a YAML string with trailing `---`.
  */
 export function buildFrontMatter(fields: {
-  title?: string;
-  author?: string;
-  date?: string;
-  tags?: string[];
+	title?: string;
+	author?: string;
+	date?: string;
+	tags?: string[];
 }): string {
-  const lines: string[] = ['---'];
-  if (fields.title)  lines.push(`title: "${fields.title}"`);
-  if (fields.author) lines.push(`author: "${fields.author}"`);
-  if (fields.date)   lines.push(`date: "${fields.date}"`);
-  if (fields.tags?.length)
-    lines.push(`tags: [${fields.tags.map((t) => `"${t}"`).join(', ')}]`);
-  lines.push('---\n');
-  return lines.join('\n');
+	const lines: string[] = ['---'];
+	if (fields.title) lines.push(`title: "${fields.title}"`);
+	if (fields.author) lines.push(`author: "${fields.author}"`);
+	if (fields.date) lines.push(`date: "${fields.date}"`);
+	if (fields.tags?.length) lines.push(`tags: [${fields.tags.map((t) => `"${t}"`).join(', ')}]`);
+	lines.push('---\n');
+	return lines.join('\n');
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,7 +37,11 @@
 		if (get(dirty) && !(await ask('You have unsaved work. Continue?'))) return;
 		if (hasNativeFS) {
 			try {
-				const [handle] = await (window as any).showOpenFilePicker({
+				const [handle] = await (
+					window as Window & {
+						showOpenFilePicker(options?: unknown): Promise<FileSystemFileHandle[]>;
+					}
+				).showOpenFilePicker({
 					types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
 				});
 				const file = await handle.getFile();
@@ -45,7 +49,9 @@
 				markdownContent.set(text);
 				fileName.set(file.name.replace(/\.md$/, ''));
 				markSaved(text);
-			} catch {}
+			} catch {
+				// ignore user cancellation
+			}
 		} else hiddenInput.click();
 	}
 
@@ -53,7 +59,11 @@
 		const txt = get(markdownContent);
 		if (hasNativeFS) {
 			try {
-				const handle = await (window as any).showSaveFilePicker({
+				const handle = await (
+					window as Window & {
+						showSaveFilePicker(options?: unknown): Promise<FileSystemFileHandle>;
+					}
+				).showSaveFilePicker({
 					suggestedName: `${get(fileName)}.md`,
 					types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }]
 				});
@@ -61,7 +71,9 @@
 				await w.write(txt);
 				await w.close();
 				markSaved(txt);
-			} catch {}
+			} catch {
+				// ignore user cancellation
+			}
 		} else {
 			const blob = new Blob([txt], { type: 'text/markdown' });
 			const url = URL.createObjectURL(blob);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,120 +2,125 @@
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
 }
 html,
 body {
-  height: 100%;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+	height: 100%;
+	font-family:
+		system-ui,
+		-apple-system,
+		'Segoe UI',
+		Roboto,
+		sans-serif;
 }
 
 /* -------- CSS variables -------- */
 :root {
-  /* palette */
-  --bg-light: #ffffff;
-  --text-light: #222;
-  --bg-dark: #1e1e1e;
-  --text-dark: #ddd;
-  --border: #c9c9c9;
-  --accent: #0d6efd;
+	/* palette */
+	--bg-light: #ffffff;
+	--text-light: #222;
+	--bg-dark: #1e1e1e;
+	--text-dark: #ddd;
+	--border: #c9c9c9;
+	--accent: #0d6efd;
 
-  /* rounded corners */
-  --radius: 8px;
+	/* rounded corners */
+	--radius: 8px;
 
-  /* misc */
-  --mono: ui-monospace, "Courier New", monospace;
-  --transition: 0.2s ease-in-out;
+	/* misc */
+	--mono: ui-monospace, 'Courier New', monospace;
+	--transition: 0.2s ease-in-out;
 }
 
 .line-numbers {
-  background: rgba(0, 0, 0, 0.04);
-  line-height: 1.5;
+	background: rgba(0, 0, 0, 0.04);
+	line-height: 1.5;
 }
 .line-numbers div {
-  height: 1.5em;
+	height: 1.5em;
 }
 html.dark .line-numbers {
-  background: rgba(255, 255, 255, 0.05);
+	background: rgba(255, 255, 255, 0.05);
 }
 
 /* light / dark bodies */
 html.light body {
-  background: var(--bg-light);
-  color: var(--text-light);
+	background: var(--bg-light);
+	color: var(--text-light);
 }
 html.dark body {
-  background: var(--bg-dark);
-  color: var(--text-dark);
+	background: var(--bg-dark);
+	color: var(--text-dark);
 }
 
 /* -------- layout container -------- */
 .editor-layout {
-  display: flex;
-  height: calc(100vh - 52px); /* header height */
-  overflow: hidden;
+	display: flex;
+	height: calc(100vh - 52px); /* header height */
+	overflow: hidden;
 }
 @media (max-width: 767px) {
-  .editor-layout {
-    flex-direction: column;
-    height: auto;
-  }
+	.editor-layout {
+		flex-direction: column;
+		height: auto;
+	}
 }
 
 /* pane basics */
 .pane {
-  flex: 1;
-  padding: 1rem;
-  overflow: auto;
-  background: var(--bg-light);
-  border-radius: var(--radius);
-  box-shadow: inset 0 0 4px rgba(0,0,0,0.05);
+	flex: 1;
+	padding: 1rem;
+	overflow: auto;
+	background: var(--bg-light);
+	border-radius: var(--radius);
+	box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.05);
 }
 html.dark .pane {
-  background: var(--bg-dark);
-  box-shadow: inset 0 0 4px rgba(255,255,255,0.05);
+	background: var(--bg-dark);
+	box-shadow: inset 0 0 4px rgba(255, 255, 255, 0.05);
 }
 .preview-pane {
-  scrollbar-width: none; /* Firefox */
-  border-radius: var(--radius);
-  background: var(--bg-light);
-  box-shadow: inset 0 0 4px rgba(0,0,0,0.05);
+	scrollbar-width: none; /* Firefox */
+	border-radius: var(--radius);
+	background: var(--bg-light);
+	box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.05);
 }
 html.dark .preview-pane {
-  background: var(--bg-dark);
-  box-shadow: inset 0 0 4px rgba(255,255,255,0.05);
+	background: var(--bg-dark);
+	box-shadow: inset 0 0 4px rgba(255, 255, 255, 0.05);
 }
 .preview-pane::-webkit-scrollbar {
-  display: none;
+	display: none;
 }
 .pane + .pane {
-  border-left: 1px solid var(--border);
+	border-left: 1px solid var(--border);
 }
 @media (max-width: 767px) {
-  .pane + .pane {
-    border-left: none;
-    border-top: 1px solid var(--border);
-  }
+	.pane + .pane {
+		border-left: none;
+		border-top: 1px solid var(--border);
+	}
 }
 
 /* -------- textarea -------- */
 textarea {
-  width: 100%;
-  height: 100%;
-  border: none;
-  resize: none;
-  font-family: var(--mono);
-  background: inherit;
-  color: inherit;
-  line-height: 1.5;
-  outline: none;
+	width: 100%;
+	height: 100%;
+	border: none;
+	resize: none;
+	font-family: var(--mono);
+	background: inherit;
+	color: inherit;
+	line-height: 1.5;
+	outline: none;
 }
 
 /* -------- markdown preview styling -------- */
 .preview-content {
-  line-height: 1.5;
+	line-height: 1.5;
 }
 .preview-content h1,
 .preview-content h2,
@@ -123,92 +128,108 @@ textarea {
 .preview-content h4,
 .preview-content h5,
 .preview-content h6 {
-  margin: 1rem 0 0.5rem;
-  font-weight: 700;
+	margin: 1rem 0 0.5rem;
+	font-weight: 700;
 }
 
-.preview-content h1 { font-size: 2rem; }
-.preview-content h2 { font-size: 1.75rem; }
-.preview-content h3 { font-size: 1.5rem; }
-.preview-content h4 { font-size: 1.25rem; }
-.preview-content h5 { font-size: 1.1rem; }
-.preview-content h6 { font-size: 1rem; }
+.preview-content h1 {
+	font-size: 2rem;
+}
+.preview-content h2 {
+	font-size: 1.75rem;
+}
+.preview-content h3 {
+	font-size: 1.5rem;
+}
+.preview-content h4 {
+	font-size: 1.25rem;
+}
+.preview-content h5 {
+	font-size: 1.1rem;
+}
+.preview-content h6 {
+	font-size: 1rem;
+}
 .preview-content p,
 .preview-content ul,
 .preview-content ol,
 .preview-content blockquote,
 .preview-content pre,
 .preview-content table {
-  margin: 0.5rem 0;
+	margin: 0.5rem 0;
 }
 
 .preview-content ul,
 .preview-content ol {
-  padding-left: 1.5rem;
-  margin: 0.5rem 0;
-  list-style-position: inside;
+	padding-left: 1.5rem;
+	margin: 0.5rem 0;
+	list-style-position: inside;
 }
 
-.preview-content ul  { list-style-type: disc;   }   /* ● item */
-.preview-content ol  { list-style-type: decimal; }   /* 1. item */
+.preview-content ul {
+	list-style-type: disc;
+} /* ● item */
+.preview-content ol {
+	list-style-type: decimal;
+} /* 1. item */
 
 .preview-content blockquote {
-  border-left: 4px solid var(--border);
-  padding-left: 1rem;
-  color: #666;
+	border-left: 4px solid var(--border);
+	padding-left: 1rem;
+	color: #666;
 }
 html.dark .preview-content blockquote {
-  color: #aaa;
-  border-color: #444;
+	color: #aaa;
+	border-color: #444;
 }
 .preview-content code {
-  background: #f5f5f5;
-  padding: 2px 4px;
-  border-radius: 4px;
-  font-family: var(--mono);
+	background: #f5f5f5;
+	padding: 2px 4px;
+	border-radius: 4px;
+	font-family: var(--mono);
 }
 html.dark .preview-content code {
-  background: #323232;
+	background: #323232;
 }
 .preview-content pre {
-  background: #f5f5f5;
-  padding: 0.75rem;
-  border-radius: 6px;
-  overflow-x: auto;
+	background: #f5f5f5;
+	padding: 0.75rem;
+	border-radius: 6px;
+	overflow-x: auto;
 }
 .preview-content [data-line]:hover {
-  background: rgba(180, 180, 180, 0.15);
+	background: rgba(180, 180, 180, 0.15);
 }
 html.dark .preview-content [data-line]:hover {
-  background: rgba(255, 255, 255, 0.08);
+	background: rgba(255, 255, 255, 0.08);
 }
 html.dark .preview-content pre {
-  background: #2b2b2b;
+	background: #2b2b2b;
 }
 
 /* --- tables --- */
 .preview-content table {
-  border-collapse: collapse;
-  width: 100%;
-  margin: 0.5rem 0;
+	border-collapse: collapse;
+	width: 100%;
+	margin: 0.5rem 0;
 }
 .preview-content th,
 .preview-content td {
-  border: 1px solid var(--border);
-  padding: 0.4rem 0.6rem;
-  text-align: left;
+	border: 1px solid var(--border);
+	padding: 0.4rem 0.6rem;
+	text-align: left;
 }
 
 /* --- task list checkboxes --- */
-.preview-content input[type="checkbox"] {
-  margin-right: 0.4rem;
+.preview-content input[type='checkbox'] {
+	margin-right: 0.4rem;
 }
 
 /* --- highlight ==mark== --- */
 .preview-content mark {
-  background: #fff59b;
-  padding: 0 0.15em;
+	background: #fff59b;
+	padding: 0 0.15em;
 }
 html.dark .preview-content mark {
-  background: #7d6b00;
+	background: #7d6b00;
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter(),
-		alias:{
+		alias: {
 			$lib: 'src/lib',
 			$components: 'src/components',
 			$stores: 'src/stores',
@@ -29,7 +29,7 @@ const config = {
 			$constants: 'src/constants',
 			$helpers: 'src/helpers',
 			$plugins: 'src/plugins',
-			$theme: 'src/theme',
+			$theme: 'src/theme'
 		}
 	}
 };

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -2,29 +2,29 @@ import { describe, it, expect } from 'vitest';
 import { parseFrontMatter, buildFrontMatter } from '../src/lib/utils';
 
 describe('parseFrontMatter', () => {
-  it('parses YAML front matter when present', () => {
-    const input = `---\ntitle: "Post"\ntags: [foo, bar]\n---\nBody text`;
-    const result = parseFrontMatter(input);
-    expect(result).not.toBeNull();
-    expect(result?.meta).toEqual({ title: 'Post', tags: ['foo', 'bar'] });
-    expect(result?.body).toBe('Body text');
-  });
+	it('parses YAML front matter when present', () => {
+		const input = `---\ntitle: "Post"\ntags: [foo, bar]\n---\nBody text`;
+		const result = parseFrontMatter(input);
+		expect(result).not.toBeNull();
+		expect(result?.meta).toEqual({ title: 'Post', tags: ['foo', 'bar'] });
+		expect(result?.body).toBe('Body text');
+	});
 
-  it('returns null when no front matter found', () => {
-    const input = 'Just body';
-    expect(parseFrontMatter(input)).toBeNull();
-  });
+	it('returns null when no front matter found', () => {
+		const input = 'Just body';
+		expect(parseFrontMatter(input)).toBeNull();
+	});
 });
 
 describe('buildFrontMatter', () => {
-  it('creates a YAML block with trailing newline', () => {
-    const yaml = buildFrontMatter({
-      title: 'A',
-      author: 'B',
-      date: '2024-01-01',
-      tags: ['x', 'y']
-    });
-    const expected = `---\ntitle: "A"\nauthor: "B"\ndate: "2024-01-01"\ntags: [\"x\", \"y\"]\n---\n`;
-    expect(yaml).toBe(expected);
-  });
+	it('creates a YAML block with trailing newline', () => {
+		const yaml = buildFrontMatter({
+			title: 'A',
+			author: 'B',
+			date: '2024-01-01',
+			tags: ['x', 'y']
+		});
+		const expected = `---\ntitle: "A"\nauthor: "B"\ndate: "2024-01-01"\ntags: ["x", "y"]\n---\n`;
+		expect(yaml).toBe(expected);
+	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,18 +11,8 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	},
-	"include": [
-		"src/**/*",
-		"@types/**/*.d.ts"
-	],
-	"exclude": [
-		"node_modules",
-		"build",
-		"dist",
-		"public",
-		".svelte-kit",
-		"*.config.js"
-	],
+	"include": ["src/**/*", "@types/**/*.d.ts"],
+	"exclude": ["node_modules", "build", "dist", "public", ".svelte-kit", "*.config.js"]
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
## Summary
- run Prettier/ESLint on repo
- fix lint warnings in components
- adjust metadata tags field spacing
- make filename input auto-size and underline on focus
- update util typings
- tidy README formatting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841fa6ea4bc8326b6cc6ceee9c21232